### PR TITLE
Allow 0x1234ABCD in custom command args.

### DIFF
--- a/js/hview.js
+++ b/js/hview.js
@@ -877,7 +877,7 @@ $(function () {
                         p = parseFloat(p);
                         data.writeStr("F", true);
                         data.writeFloat(p);
-                    } else if (p.match(/^[+-]?\s*\d+$/)) {
+                    } else if (p.match(/^[+-]?(0x)?[0-9a-fA-F]+$/)) {
                         p = parseInt(p);
                         data.writeStr("I", true);
                         data.writeInt(p);


### PR DESCRIPTION
Makes it much easier to do things like this:

  setBackgroundColor(0x80FFFF00)