### PR TITLE
Converting 'var' into 'let' and 'const'.

### DIFF
--- a/js/activity_list.js
+++ b/js/activity_list.js
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 /* Action to refresh activity list */
-var activityListAction = function (initializer) {
+const activityListAction = function (initializer) {
     progress.show();
-    var content = $("#device-list-content").empty();
+    const content = $("#device-list-content").empty();
 
-    var jdwpErrorContainer;
-    var windowLoaded;
-    var mainContent = $("<div>").appendTo(content);
+    let jdwpErrorContainer;
+    let windowLoaded;
+    const mainContent = $("<div>").appendTo(content);
 
-    var newApiChk = null;
+    let newApiChk = null;
 
-    var startHView = function () {
-        var info = $(this).data("appInfo");
+    const startHView = function () {
+        const info = $(this).data("appInfo");
         if (newApiChk != null && newApiChk.is(':checked')) {
             info.use_new_api = false;
         }
@@ -35,9 +35,9 @@ var activityListAction = function (initializer) {
         hViewAction(info);
     }
 
-    var renderActivities = function(container, list) {
+    const renderActivities = function(container, list) {
 
-        var buttonbar = $("<div class='button-bar'>").css({display: "flex"}).appendTo(container);
+        const buttonbar = $("<div class='button-bar'>").css({display: "flex"}).appendTo(container);
         if (list.use_new_api) {
             newApiChk = $('<input type="checkbox" />');
             $("<label class='old-api'>").appendTo(buttonbar).append(newApiChk).append($("<span class='slider'>")).append($("<span class='text'>").text("Load custom properties"));
@@ -53,12 +53,12 @@ var activityListAction = function (initializer) {
         if (list.hasIcons) {
             container.addClass("has-icons")
         }
-        for (var i = 0; i < list.length; i++) {
-            var l = list[i];
-            var entry = $("<div>").data("appInfo", l).appendTo(container).click(startHView).addClass("entry");
+        for (let i = 0; i < list.length; i++) {
+            const l = list[i];
+            const entry = $("<div>").data("appInfo", l).appendTo(container).click(startHView).addClass("entry");
 
             if (list.hasIcons) {
-                var icon = $('<div class="icon">').appendTo(entry).attr("icon-pid", l.pid);
+                const icon = $('<div class="icon">').appendTo(entry).attr("icon-pid", l.pid);
                 if (l.icon && l.icon.value) {
                     icon.css("background-image", `url(${l.icon.value})`);
                 }
@@ -68,7 +68,7 @@ var activityListAction = function (initializer) {
                 l.name = "---";
             }
             $('<div class="title">').text(l.name).appendTo(entry);
-            var subText;
+            let subText;
             if (l.pid != undefined && l.pname != undefined) {
                 subText = `${l.pname} (${l.pid})`;
             } else if (l.pname != undefined) {
@@ -84,11 +84,11 @@ var activityListAction = function (initializer) {
         }
     }
 
-    var callbacks = {
+    const callbacks = {
         jdwpError: function () {
             if (!jdwpErrorContainer) {
                 jdwpErrorContainer = $("<div>").prependTo(content)
-                    .showError("Using old API. Something bad might have heppend. You should probably take a break.");
+                    .showError("Using old API. Something bad might have happened. You should probably take a break.");
             }
         },
 

--- a/js/adb/adb_msg.js
+++ b/js/adb/adb_msg.js
@@ -26,7 +26,7 @@ const AUTH_TYPE_TOKEN = 1;
 const AUTH_TYPE_SIGNATURE = 2;
 const AUTH_TYPE_RSAPUBLICKEY = 3;
 
-var commandMap = [];
+const commandMap = [];
 commandMap[SYNC_COMMAND] = "SYNC_COMMAND";
 commandMap[CNXN_COMMAND] = "CNXN_COMMAND";
 commandMap[OPEN_COMMAND] = "OPEN_COMMAND";
@@ -67,7 +67,7 @@ function computeAdbMessageDataCrc32(data) {
  * @return AdbMessageHeader object
  */
 function constructAdbHeader(command, arg0, arg1, data, version) {
-    var checksum;
+    let checksum;
     if (version >= VERSION_SKIP_CHECKSUM && command != AUTH_COMMAND && command != CNXN_COMMAND) {
         checksum = 0;
     } else if (data) {
@@ -149,10 +149,10 @@ function verifyAdbMessageData(header, data) {
 }
 
 /**
- * Appends to array bufferes
+ * Appends to array buffers
  */
 function appendBuffer(first, last) {
-    var result = new Uint8Array(first.byteLength + last.byteLength);
+    const result = new Uint8Array(first.byteLength + last.byteLength);
     result.set(first, 0);
     result.set(last, first.byteLength);
     return result;

--- a/js/adb/crypto.js
+++ b/js/adb/crypto.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var AdbKey = (function () {
+let AdbKey = (function () {
     const ADB_WEB_CRYPTO_ALGORITHM = {
         name: 'RSASSA-PKCS1-v1_5',
         hash: {
@@ -63,7 +63,7 @@ var AdbKey = (function () {
         const rr = r.multiply(r).mod(key.n);
 
         const buffer = new ArrayBuffer(PUBKEY_ENCODED_SIZE);
-        var dv = new DataView(buffer);
+        let dv = new DataView(buffer);
         dv.setUint32(0, MODULUS_SIZE_WORDS, true);
         dv.setUint32(WORD_SIZE, n0inv, true);
         new Uint8Array(dv.buffer, dv.byteOffset, dv.byteLength / Uint8Array.BYTES_PER_ELEMENT).set(bigIntToFixedByteArray(key.n, MODULUS_SIZE).reverse(), 2 * WORD_SIZE);
@@ -94,22 +94,21 @@ var AdbKey = (function () {
      * Generates a new key and stores it in local storate
      */
     async function generateNewKeyPair() {
-        var keypair = await Promise.resolve(crypto.subtle.generateKey({
+        const keypair = await Promise.resolve(crypto.subtle.generateKey({
             ...ADB_WEB_CRYPTO_ALGORITHM,
             modulusLength: MODULUS_SIZE_BITS,
             publicExponent: PUBLIC_EXPONENT,
         },
             ADB_WEB_CRYPTO_EXPORTABLE, ADB_WEB_CRYPTO_OPERATIONS));
-        var jwk = await Promise.resolve(crypto.subtle.exportKey('jwk', keypair.publicKey));
+        const jwk = await Promise.resolve(crypto.subtle.exportKey('jwk', keypair.publicKey));
 
-        var jsbnKey = new RSAKey();
+        const jsbnKey = new RSAKey();
         jsbnKey.setPublic(decodeWebBase64ToHex(jwk.n), decodeWebBase64ToHex(jwk.e));
 
         const bytes = encodeAndroidPublicKeyBytes(jsbnKey);
         const userInfo = 'unknown@web-hv';
-        var publicKey = btoa(String.fromCharCode.apply(null, bytes)) + ' ' + userInfo;
 
-        var fullKey = await Promise.resolve(crypto.subtle.exportKey("jwk", keypair.privateKey));
+        const fullKey = await Promise.resolve(crypto.subtle.exportKey("jwk", keypair.privateKey));
         fullKey.publicKey = btoa(String.fromCharCode.apply(null, bytes)) + ' ' + userInfo;
 
         localStorage.cryptoKey = JSON.stringify(fullKey);
@@ -120,11 +119,11 @@ var AdbKey = (function () {
         window.dd = this;
 
         this.fullKey = localStorage.cryptoKey;
-        this.keyPromise = !!this.fullKey ? Promise.resolve(this.fullKey) : generateNewKeyPair();
+        this.keyPromise = this.fullKey ? Promise.resolve(this.fullKey) : generateNewKeyPair();
     }
 
     AdbKeyInternal.prototype.sign = function (token) {
-        var jwk = JSON.parse(this.fullKey);
+        const jwk = JSON.parse(this.fullKey);
 
         key = new RSAKey();
         key.setPrivateEx(
@@ -133,7 +132,6 @@ var AdbKey = (function () {
             decodeWebBase64ToHex(jwk.q), decodeWebBase64ToHex(jwk.dp),
             decodeWebBase64ToHex(jwk.dq), decodeWebBase64ToHex(jwk.qi));
 
-        const bitLength = key.n.bitLength();
         // Message Layout (size equals that of the key modulus):
         // 00 01 FF FF FF FF ... FF [ASN.1 PREFIX] [TOKEN]
         const message = new Uint8Array(MODULUS_SIZE);
@@ -159,8 +157,8 @@ var AdbKey = (function () {
     }
 
     AdbKeyInternal.prototype.publicKey = async function () {
-        var json = await this.keyPromise;
-        var fullKey = JSON.parse(json);
+        const json = await this.keyPromise;
+        const fullKey = JSON.parse(json);
         return fullKey.publicKey;
     }
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -12,30 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var CLS_EXPANDABLE = "expandable";
-var CLS_CLOSED = "closed";
-var CLS_TREENODE = "treenode";
-var CLS_SELECTED = "selected";
-var CLS_HOVER = "hover";
-var CLS_FORCE_NO_BG = "force-no-bg";
-var CLS_HIDE_MY_BG = "hide-my-bg";
-var CLS_DISABLED = "disabled";
-var CLS_WITH_ARROW = "with_arrow";
-var CLS_MULTI_TOGGLE = "multi-toggle"
-var CLS_COLORWELL = "colorwell";
+const CLS_EXPANDABLE = "expandable";
+const CLS_CLOSED = "closed";
+const CLS_TREENODE = "treenode";
+const CLS_SELECTED = "selected";
+const CLS_HOVER = "hover";
+const CLS_FORCE_NO_BG = "force-no-bg";
+const CLS_HIDE_MY_BG = "hide-my-bg";
+const CLS_DISABLED = "disabled";
+const CLS_WITH_ARROW = "with_arrow";
+const CLS_MULTI_TOGGLE = "multi-toggle"
+const CLS_COLORWELL = "colorwell";
 
-var URL_LOADING = "_loading_";
+const URL_LOADING = "_loading_";
 
-var TYPE_ERROR = -1;
-var TYPE_ZIP = 0;
-var TYPE_OLD = 1;
-var TYPE_JDWP = 2;
-var TYPE_BUG_REPORT = 3;
-var TYPE_BUG_REPORT_V2 = 4;  // Bug report with encoded view hierarchy
+const TYPE_ERROR = -1;
+const TYPE_ZIP = 0;
+const TYPE_OLD = 1;
+const TYPE_JDWP = 2;
+const TYPE_BUG_REPORT = 3;
+const TYPE_BUG_REPORT_V2 = 4;  // Bug report with encoded view hierarchy
 
-
-var CMD_CONVERT_TO_STRING = 1;
-var CMD_PARSE_OLD_DATA = 2;
-var CMD_USE_PROPERTY_MAP = 4;
-var CMD_DEFLATE_STRING = 8;
-var CMD_SKIP_8_BITS = 16;
+const CMD_CONVERT_TO_STRING = 1;
+const CMD_PARSE_OLD_DATA = 2;
+const CMD_USE_PROPERTY_MAP = 4;
+const CMD_DEFLATE_STRING = 8;
+const CMD_SKIP_8_BITS = 16;

--- a/js/ddmlib/DataInputStream.js
+++ b/js/ddmlib/DataInputStream.js
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var swapAltElements = function(arr) {
-    for (var i = 0; i < arr.length; i += 2) {
-        var tmp = arr[i];
+const swapAltElements = function(arr) {
+    for (let i = 0; i < arr.length; i += 2) {
+        const tmp = arr[i];
         arr[i] = arr[i + 1];
         arr[i + 1] = tmp;
     }
@@ -37,25 +37,25 @@ DataInputStream.prototype.read = function() {
 }
 
 DataInputStream.prototype.readInt = function() {
-    var pos = this.pos;
+    const pos = this.pos;
     this.pos += 4;
     return this._view.getInt32(pos, !this.highFirst);
 }
 
 DataInputStream.prototype.readShort = function() {
-    var pos = this.pos;
+    const pos = this.pos;
     this.pos += 2;
     return this._view.getInt16(pos, !this.highFirst);
 }
 
 DataInputStream.prototype.readFloat = function() {
-    var pos = this.pos;
+    const pos = this.pos;
     this.pos += 4;
     return this._view.getFloat32(pos, !this.highFirst);
 }
 
 DataInputStream.prototype.readDouble = function() {
-    var pos = this.pos;
+    const pos = this.pos;
     this.pos += 8;
     return this._view.getFloat64(pos, !this.highFirst);
 };
@@ -69,7 +69,7 @@ DataInputStream.prototype.readStr = function(len) {
     if (len == undefined) {
         len = this.readInt();
     }
-    var slice = this.data.subarray(this.pos, this.pos += 2 * len);
+    let slice = this.data.subarray(this.pos, this.pos += 2 * len);
     if (this.highFirst) {
         swapAltElements(slice);
     }
@@ -78,8 +78,8 @@ DataInputStream.prototype.readStr = function(len) {
 }
 
 DataInputStream.prototype.readStrSmall = function() {
-    var len = this.readShort();
-    var slice = this.data.subarray(this.pos, this.pos += len);
+    const len = this.readShort();
+    let slice = this.data.subarray(this.pos, this.pos += len);
     slice = new Uint8Array(slice.buffer, slice.byteOffset, len);
     return String.fromCharCode.apply(null, slice);
 }

--- a/js/ddmlib/DataOutputStream.js
+++ b/js/ddmlib/DataOutputStream.js
@@ -32,8 +32,8 @@ DataOutputStream.prototype.writeByte = function(byte, pos) {
 
 DataOutputStream.prototype.writeBytes = function(bytes, pos) {
     if (pos == undefined) pos = this.data.length;
-    var length = bytes.length;
-    for (var i = 0; i < length; i++, pos++) {
+    const length = bytes.length;
+    for (let i = 0; i < length; i++, pos++) {
         this.data[pos] = bytes[i];
     }
 }
@@ -47,16 +47,16 @@ DataOutputStream.prototype.writeInt = function(number, pos) {
 }
 
 DataOutputStream.prototype.writeFloat = function(number, pos) {
-    var arr = new Float32Array(1);
+    let arr = new Float32Array(1);
     arr[0] = number;
     arr = new Int32Array(arr.buffer, arr.byteOffset);
     this.writeInt(arr[0]);
 }
 
 DataOutputStream.prototype.writeStr = function(str, doNotWriteLen) {
-    var buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
-    var bufView = new Uint16Array(buf);
-    for (var i = 0; i < str.length; i++) {
+    const buf = new ArrayBuffer(str.length * 2); // 2 bytes for each char
+    let bufView = new Uint16Array(buf);
+    for (let i = 0; i < str.length; i++) {
         bufView[i] = str.charCodeAt(i);
     }
     bufView = new Uint8Array(buf);

--- a/js/ddmlib/jdwp.js
+++ b/js/ddmlib/jdwp.js
@@ -29,7 +29,7 @@ jdwp.prototype.STATUS_CONNECTED = 2;
 
 jdwp.prototype._onDisconnect = function () {
     this.status = this.STATUS_DISCONNECTED;
-    for (var i = 0; i < this.callbacks.length; i++) {
+    for (let i = 0; i < this.callbacks.length; i++) {
         if (this.callbacks[i]) {
             this.callbacks[i].reject();
         }
@@ -43,14 +43,14 @@ jdwp.prototype._onDisconnect = function () {
 }
 
 jdwp.prototype._connect = function () {
-    var that = this;
+    const that = this;
     this.status = this.STATUS_CONNECTING;
 
-    var socket = this.device.openStream("jdwp:" + this.pid);
+    const socket = this.device.openStream("jdwp:" + this.pid);
     socket.onClose = this._onDisconnect.bind(this);
     socket.keepOpen = true;
 
-    var cmd = "JDWP-Handshake";
+    const cmd = "JDWP-Handshake";
     socket.read(cmd.length, function (data) {
         data = ab2str(data);
         if (data == cmd) {
@@ -65,27 +65,27 @@ jdwp.prototype._connect = function () {
 
 jdwp.prototype._onConnect = function () {
     this.status = this.STATUS_CONNECTED;
-    var calls = this.pendingCalls;
+    const calls = this.pendingCalls;
     this.pendingCalls = [];
 
-    for (var i = 0; i < calls.length; i++) {
+    for (let i = 0; i < calls.length; i++) {
         this.socket.write(calls[i]);
     }
     this._readNextChunk();
 }
 
 jdwp.prototype._readNextChunk = function () {
-    var that = this;
+    const that = this;
     this.socket.read(11, function (data) {
-        var header = new DataInputStream(new Uint8Array(data));
-        var len = header.readInt();
-        var seq = header.readInt();
-        var flags = header.read();
-        var isCommand = flags != 128;
+        const header = new DataInputStream(new Uint8Array(data));
+        const len = header.readInt();
+        const seq = header.readInt();
+        const flags = header.read();
+        const isCommand = flags != 128;
 
         that.socket.read(len - 11, function (data) {
-            var reader = new DataInputStream(new Uint8Array(data));
-            var type = reader.readInt();   // chunk type
+            const reader = new DataInputStream(new Uint8Array(data));
+            const type = reader.readInt();   // chunk type
             reader.readInt();   // result length;
 
             if (isCommand) {
@@ -113,15 +113,15 @@ jdwp.prototype.destroy = function () {
  * @returns a promise for the result
  */
 jdwp.prototype.writeChunk = function (type, data) {
-    var result = deferred();
+    const result = deferred();
     if (data.constructor == DataOutputStream) {
         data = data.data;
     }
 
-    var packet = new DataOutputStream();
+    let packet = new DataOutputStream();
     packet.writeInt(11 + 8 + data.length); // package length
 
-    var seq = this.seq++;
+    const seq = this.seq++;
     packet.writeInt(seq);
 
     packet.writeByte(0);    // flags
@@ -146,13 +146,13 @@ jdwp.prototype.writeChunk = function (type, data) {
     return result;
 }
 
-var CHUNK_TYPES = {};
-var getChunkType = function (type) {
+const CHUNK_TYPES = {};
+const getChunkType = function (type) {
     if (type.constructor == String) {
         if (CHUNK_TYPES[type] == undefined) {
-            var buf = new ArrayBuffer(4);
-            var arr = new Uint8Array(buf);
-            for (var i = 0; i < 4; i++) {
+            const buf = new ArrayBuffer(4);
+            const arr = new Uint8Array(buf);
+            for (let i = 0; i < 4; i++) {
                 arr[3 - i] = type.charCodeAt(i);
             }
             CHUNK_TYPES[type] = new Int32Array(buf)[0];

--- a/js/ddmlib/parser_v1.js
+++ b/js/ddmlib/parser_v1.js
@@ -13,21 +13,21 @@
 // limitations under the License.
 
 
-var countFrontWhitespace = function(line) {
-    var m = line.match(/^\s+/);
+const countFrontWhitespace = function(line) {
+    const m = line.match(/^\s+/);
     return m ? m[0].length : 0
 };
 
-var loadProperties = function(node, data) {
-    var start = 0;
-    var stop;
+const loadProperties = function(node, data) {
+    let start = 0;
+    let stop;
 
     do {
-        var index = data.indexOf('=', start);
-        var property = new VN_Property(data.substring(start, index));
+        const index = data.indexOf('=', start);
+        const property = new VN_Property(data.substring(start, index));
 
-        var index2 = data.indexOf(',', index + 1);
-        var length = parseInt(data.substring(index + 1, index2));
+        const index2 = data.indexOf(',', index + 1);
+        const length = parseInt(data.substring(index + 1, index2));
         start = index2 + 1 + length;
         property.value = data.substring(index2 + 1, index2 + 1 + length);
 
@@ -47,31 +47,31 @@ var loadProperties = function(node, data) {
 /**
  * Parses the view node data and returns the root node
  */
-var parseNode = function(data) {
-    var stack = [];
-    var root = null;
-    var lastNode = null;
-    var lastWhitespaceCount = -INT_MIN_VALUE;
+const parseNode = function(data) {
+    const stack = [];
+    let root = null;
+    let lastNode = null;
+    let lastWhitespaceCount = -INT_MIN_VALUE;
     data = data.split("\n");
-    for (var l = 0; l < data.length - 1; l++) {
-        var line = data[l];
+    for (let l = 0; l < data.length - 1; l++) {
+        let line = data[l];
         if (line.toUpperCase() == "DONE.") {
             break;
         }
 
-        var whitespaceCount = countFrontWhitespace(line);
+        const whitespaceCount = countFrontWhitespace(line);
         if (lastWhitespaceCount < whitespaceCount) {
             stack.push(lastNode);
         } else if (stack.length) {
-            var count = lastWhitespaceCount - whitespaceCount;
-            for (var i = 0; i < count; i++) {
+            const count = lastWhitespaceCount - whitespaceCount;
+            for (let i = 0; i < count; i++) {
                 stack.pop();
             }
         }
 
         lastWhitespaceCount = whitespaceCount;
         line = line.trim();
-        var index = line.indexOf(' ');
+        const index = line.indexOf(' ');
         lastNode = new ViewNode(line.substring(0, index));
 
         line = line.substring(index + 1);
@@ -82,7 +82,7 @@ var parseNode = function(data) {
         }
 
         if (stack.length) {
-            var parent = stack[stack.length - 1];
+            const parent = stack[stack.length - 1];
             parent.children.push(lastNode);
         }
     }

--- a/js/ddmlib/parser_v2.js
+++ b/js/ddmlib/parser_v2.js
@@ -13,24 +13,24 @@
 // limitations under the License.
 
 // Prefixes for simple primitives. These match the JNI definitions.
-var SIG_BOOLEAN = 'Z'.charCodeAt(0);
-var SIG_BYTE = 'B'.charCodeAt(0);
-var SIG_SHORT = 'S'.charCodeAt(0);
-var SIG_INT = 'I'.charCodeAt(0);
-var SIG_LONG = 'J'.charCodeAt(0);
-var SIG_FLOAT = 'F'.charCodeAt(0);
-var SIG_DOUBLE = 'D'.charCodeAt(0);
+const SIG_BOOLEAN = 'Z'.charCodeAt(0);
+const SIG_BYTE = 'B'.charCodeAt(0);
+const SIG_SHORT = 'S'.charCodeAt(0);
+const SIG_INT = 'I'.charCodeAt(0);
+const SIG_LONG = 'J'.charCodeAt(0);
+const SIG_FLOAT = 'F'.charCodeAt(0);
+const SIG_DOUBLE = 'D'.charCodeAt(0);
 
 // Prefixes for some commonly used objects
-var SIG_STRING = 'R'.charCodeAt(0);
+const SIG_STRING = 'R'.charCodeAt(0);
 
-var SIG_MAP = 'M'.charCodeAt(0); // a map with an short key
-var SIG_END_MAP = 0;
+const SIG_MAP = 'M'.charCodeAt(0); // a map with an short key
+const SIG_END_MAP = 0;
 
-var readMap = function(stream) {
-    var map = [];
+const readMap = function(stream) {
+    const map = [];
     while (true) {
-        var key = readObject(stream);
+        const key = readObject(stream);
         if (typeof(key) != "number") {
             throw "Invalid data";
         }
@@ -42,8 +42,8 @@ var readMap = function(stream) {
     return map;
 }
 
-var readObject = function(stream) {
-    var sig = stream.read();
+const readObject = function(stream) {
+    const sig = stream.read();
     switch (sig) {
         case SIG_BOOLEAN:
             return stream.read() == 0 ? "false" : "true";
@@ -68,25 +68,25 @@ var readObject = function(stream) {
     }
 }
 
-var nameIndex;
-var hashIndex;
-var childCountIndex;
-var childIndex = [];
-var pTable;
+let nameIndex;
+let hashIndex;
+let childCountIndex;
+const childIndex = [];
+let pTable;
 
-var parseNodeObj = function(nodeData) {
-    var name = nodeData[nameIndex];
-    var hash = parseInt(nodeData[hashIndex]).toString(16).toLowerCase();
+const parseNodeObj = function(nodeData) {
+    const name = nodeData[nameIndex];
+    const hash = parseInt(nodeData[hashIndex]).toString(16).toLowerCase();
 
-    var node = new ViewNode(name + "@" + hash);
-    for (var i = 0; i < nodeData.length; i++) {
+    const node = new ViewNode(name + "@" + hash);
+    for (let i = 0; i < nodeData.length; i++) {
         if (nodeData[i] == undefined || nodeData[i] == null || nodeData[i].constructor == Array) {
             continue;
         }
         if (pTable[i].indexOf("meta:") == 0) {
             continue;
         }
-        var property = new VN_Property(pTable[i]);
+        const property = new VN_Property(pTable[i]);
         property.value = nodeData[i];
 
         node.properties.push(property);
@@ -94,9 +94,9 @@ var parseNodeObj = function(nodeData) {
     }
 
     if (nodeData[childCountIndex]) {
-        var total = nodeData[childCountIndex];
-        for (var i = 0; i < total; i++) {
-            var child = parseNodeObj(nodeData[childIndex[i]]);
+        const total = nodeData[childCountIndex];
+        for (let i = 0; i < total; i++) {
+            const child = parseNodeObj(nodeData[childIndex[i]]);
             node.children.push(child);
         }
     }
@@ -107,16 +107,16 @@ var parseNodeObj = function(nodeData) {
     return node;
 }
 
-var parseNode = function(bytes, bitShift) {
-    var bytesLen = bytes.length;
-    var stream = new DataInputStream(bytes);
+const parseNode = function(bytes, bitShift) {
+    const bytesLen = bytes.length;
+    const stream = new DataInputStream(bytes);
     stream.pos = bitShift;
 
-    var views = [];
-    var globalProps = {};
+    const views = [];
+    const globalProps = {};
 
     while (stream.pos < bytesLen) {
-        var obj = readObject(stream);
+        const obj = readObject(stream);
         if (obj.constructor == Array) {
             views.push(obj);
         } else {
@@ -133,17 +133,17 @@ var parseNode = function(bytes, bitShift) {
     hashIndex = pTable.indexOf("meta:__hash__");
     childCountIndex = pTable.indexOf("meta:__childCount__");
 
-    for (var i = 0; i < pTable.length; i++) {
+    for (let i = 0; i < pTable.length; i++) {
         if (pTable[i] != undefined && pTable[i].indexOf("meta:__child__") == 0) {
             childIndex[parseInt(pTable[i].substr(14))] = i;
         }
     }
 
-    var root = parseNodeObj(views[0]);
+    const root = parseNodeObj(views[0]);
     root.updateNodeDrawn();
 
-    var windowLeftIndex = pTable.indexOf("window:left");
-    var windowTopIndex = pTable.indexOf("window:top");
+    const windowLeftIndex = pTable.indexOf("window:left");
+    const windowTopIndex = pTable.indexOf("window:top");
     if (windowLeftIndex >= 0 && windowTopIndex >= 0) {
         root.windowX = globalProps[windowLeftIndex];
         root.windowY = globalProps[windowTopIndex];

--- a/js/ddmlib/viewnode.js
+++ b/js/ddmlib/viewnode.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-var INT_MIN_VALUE = -2147483648;
+const INT_MIN_VALUE = -2147483648;
 
 function VN_Property(fullname) {
     this.name = fullname;
@@ -21,9 +21,9 @@ function VN_Property(fullname) {
     this.type = "Uncategorized";
     this.fullname = fullname;
 
-    var colonIndex = fullname.indexOf(':');
+    const colonIndex = fullname.indexOf(':');
     if (colonIndex > 0) {
-        var type = fullname.substring(0, colonIndex);
+        const type = fullname.substring(0, colonIndex);
         this.type = type.charAt(0).toUpperCase() + type.slice(1);
         this.name = fullname.substring(colonIndex + 1);
     }
@@ -43,7 +43,7 @@ function ViewNode(name) {
 }
 
 ViewNode.prototype.getBoolean = function(name, dValue) {
-    var p = this.getProp(name);
+    const p = this.getProp(name);
     if (p) {
         return p.value == 'true';
     }
@@ -52,7 +52,7 @@ ViewNode.prototype.getBoolean = function(name, dValue) {
 
 
 ViewNode.prototype.getInt  = function(name, dValue) {
-    var p = this.getProp(name);
+    const p = this.getProp(name);
     if (p) {
         try {
             return parseInt(p.value);
@@ -62,7 +62,7 @@ ViewNode.prototype.getInt  = function(name, dValue) {
 }
 
 ViewNode.prototype.getFloat  = function(name, dValue) {
-    var p = this.getProp(name);
+    const p = this.getProp(name);
     if (p) {
         try {
             return parseFloat(p.value);
@@ -73,7 +73,7 @@ ViewNode.prototype.getFloat  = function(name, dValue) {
 
 ViewNode.prototype.updateNodeDrawn = function() {
     this.nodeDrawn = !this.willNotDraw;
-    for (var i = 0; i < this.children.length; i++) {
+    for (let i = 0; i < this.children.length; i++) {
         this.children[i].updateNodeDrawn();
         this.nodeDrawn |= (this.children[i].nodeDrawn && this.children[i].isVisible);
     }
@@ -115,7 +115,7 @@ ViewNode.prototype.loadCommonProperties = function(map) {
     this.scaleX = this.getFloat("scaleX", 1);
     this.scaleY = this.getFloat("scaleY", 1);
 
-    var descProp = this.getProp("contentDescription");
+    let descProp = this.getProp("contentDescription");
     this.contentDesc = descProp != null && descProp.value && descProp.value != "null"
         ? descProp.value : null;
 
@@ -125,7 +125,7 @@ ViewNode.prototype.loadCommonProperties = function(map) {
             ? descProp.value : null;
     }
 
-    var visibility = this.getProp("visibility");
+    const visibility = this.getProp("visibility");
     this.isVisible = !visibility || visibility.value == 0 || visibility.value == "VISIBLE";
 
     delete this.getProp;

--- a/js/ddmlib/worker.js
+++ b/js/ddmlib/worker.js
@@ -14,29 +14,29 @@
 
 importScripts("viewnode.js");
 
-var CMD_CONVERT_TO_STRING = 1;
-var CMD_PARSE_OLD_DATA = 2;
-var CMD_USE_PROPERTY_MAP = 4;
-var CMD_DEFLATE_STRING = 8;
-var CMD_SKIP_8_BITS = 16;
+const CMD_CONVERT_TO_STRING = 1;
+const CMD_PARSE_OLD_DATA = 2;
+const CMD_USE_PROPERTY_MAP = 4;
+const CMD_DEFLATE_STRING = 8;
+const CMD_SKIP_8_BITS = 16;
 
-var commonProps = null;
+let commonProps = null;
 
 function convertToString(data) {
-    var total = data.length;
-    var result = "";
-    for (var st = 8; st < total; st++) {
+    const total = data.length;
+    let result = "";
+    for (let st = 8; st < total; st++) {
         result += String.fromCharCode(data[st]);
     }
     return result;
 }
 
 self.onmessage = function(e) {
-    var msg = e.data;
-    var cmd = msg.cmd;
-    var data = msg.data;
+    const msg = e.data;
+    const cmd = msg.cmd;
+    let data = msg.data;
 
-    var bitShift = 0;
+    let bitShift = 0;
 
     if ((cmd & CMD_DEFLATE_STRING) != 0) {
         importScripts("../../third_party/pako/pako_inflate.min.js");
@@ -79,7 +79,7 @@ self.onmessage = function(e) {
         importScripts("parser_v2.js");
     }
 
-    var rootNode = parseNode(data, bitShift);
+    const rootNode = parseNode(data, bitShift);
     postMessage({
         root: rootNode
     });

--- a/js/hview.js
+++ b/js/hview.js
@@ -12,25 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var hViewAction;
-var currentAppInfo;
+let hViewAction;
 
 $(function () {
-    var KEY_DIVIDER = "divider";
+    let currentAppInfo;
+    const KEY_DIVIDER = "divider";
 
-    var currentRootNode = null;
-    var selectedNode;
-    var favoriteProperties = [];
-    var viewController;
-    var showHiddenNodes = false;
-    var valueTypeMap = {};
+    let currentRootNode = null;
+    let selectedNode;
+    let favoriteProperties = [];
+    let viewController;
+    let showHiddenNodes = false;
+    let valueTypeMap = {};
 
-    var closedSections = {};
+    const closedSections = {};
 
     // Load favorite properties
     if (localStorage.favoriteProps) {
         try {
-            var tmp = JSON.parse(localStorage.favoriteProps);
+            const tmp = JSON.parse(localStorage.favoriteProps);
             if (tmp && tmp.constructor == Array) {
                 favoriteProperties = tmp;
             }
@@ -40,7 +40,7 @@ $(function () {
     // Load favorite properties
     if (localStorage.valueTypeMap) {
         try {
-            var tmp = JSON.parse(localStorage.valueTypeMap);
+            const tmp = JSON.parse(localStorage.valueTypeMap);
             if (tmp && tmp.constructor == Object) {
                 valueTypeMap = tmp;
             }
@@ -48,17 +48,17 @@ $(function () {
     }
 
     // Create dividers
-    var shouldSaveResizeData = function() {
+    const shouldSaveResizeData = function() {
         return !$("#hviewtabs").is(":visible");
     }
 
-    var createDaggerDownControl = function(divider) {
-        var invalue1 = parseInt(divider.e1.css(divider.right));
-        var invalue2 = parseInt(divider.e2.css(divider.width));
-        var invalueDragger = parseInt(divider.dragger.css(divider.right));
+    const createDaggerDownControl = function(divider) {
+        const invalue1 = parseInt(divider.e1.css(divider.right));
+        const invalue2 = parseInt(divider.e2.css(divider.width));
+        const invalueDragger = parseInt(divider.dragger.css(divider.right));
 
-        var v1 = divider.e1[divider.width]();
-        var v2 = divider.e2[divider.width]();
+        const v1 = divider.e1[divider.width]();
+        const v2 = divider.e2[divider.width]();
 
         if (v1 == 0 || v2 == 0) {
             return function() {};
@@ -80,22 +80,22 @@ $(function () {
         }
     }
 
-    var handleMouseDown = function(e) {
-        var divider = $(this).data(KEY_DIVIDER);
-        var start = e[divider.pageX];
-        var control = createDaggerDownControl(divider);
+    const handleMouseDown = function(e) {
+        const divider = $(this).data(KEY_DIVIDER);
+        const start = e[divider.pageX];
+        const control = createDaggerDownControl(divider);
 
-        var handleMouseMove = function(e) {
+        const handleMouseMove = function(e) {
             control(e[divider.pageX] - start);
         }
 
-        var handleMouseUp = function(e) {
+        const handleMouseUp = function(e) {
             $(document).unbind();
 
             // Save settings.
-            var data = {};
+            let data = {};
             $(".divider").each(function () {
-                var obj = $(this).data(KEY_DIVIDER);
+                const obj = $(this).data(KEY_DIVIDER);
                 data[$(this).attr("id")] = obj.dragger.css(obj.right);
             });
             if (shouldSaveResizeData()) {
@@ -109,16 +109,16 @@ $(function () {
         }).bind("touchend", handleMouseUp);
     }
 
-    var handleTouchStart = function(e) {
+    const handleTouchStart = function(e) {
         e.preventDefault();
         handleMouseDown.apply(this, e.originalEvent.touches);
     }
 
     $(".divider").each(function () {
-        var el = $(this);
-        var controls = el.attr("control").split(",");
+        const el = $(this);
+        const controls = el.attr("control").split(",");
 
-        var obj = {
+        const obj = {
             dragger: el,
             pageX: controls[0],
             right: controls[1],
@@ -132,16 +132,16 @@ $(function () {
     }).mousedown(handleMouseDown).bind("touchstart", handleTouchStart);
 
     // Apply resize data
-    var applyResizeData = function() {
+    const applyResizeData = function() {
         if (localStorage.resizeData && shouldSaveResizeData()) {
-            let data = JSON.parse(localStorage.resizeData);
-            for (var id in data) {
-                var divider = $("#" + id).data(KEY_DIVIDER);
+            const data = JSON.parse(localStorage.resizeData);
+            for (const id in data) {
+                const divider = $("#" + id).data(KEY_DIVIDER);
                 if (!divider || (typeof data[id]) != "string") {
                     continue;
                 }
-                var invalueDragger = parseInt(divider.dragger.css(divider.right));
-                var val = parseInt(data[id]);
+                const invalueDragger = parseInt(divider.dragger.css(divider.right));
+                const val = parseInt(data[id]);
                 createDaggerDownControl(divider)(invalueDragger - val);
             }
         }
@@ -149,11 +149,11 @@ $(function () {
 
     // In case of properties box, its width can change with changes to right panel.
     (function () {
-        var obj = $("#properties-divider").data(KEY_DIVIDER);
+        const obj = $("#properties-divider").data(KEY_DIVIDER);
         $("#rcontent").on("resizing", function () {
-            var w1 = obj.e1.width();
+            const w1 = obj.e1.width();
             if (w1 < obj.l1) {
-                var delta = obj.l1 - w1;
+                const delta = obj.l1 - w1;
 
                 obj.e1.css("right", parseInt(obj.e1.css("right")) - delta);
                 obj.e2.css("width", parseInt(obj.e2.css("width")) - delta);
@@ -163,34 +163,34 @@ $(function () {
     })();
 
     /********************************* Filter properties *********************************/
-    var filterProperties = function () {
-        var q = $("#pfilter").val().trim().toLocaleLowerCase();
-        var sections = $(".pcontainer .expandable");
-        var total = 0;
+    const filterProperties = function () {
+        const q = $("#pfilter").val().trim().toLocaleLowerCase();
+        const sections = $(".pcontainer .expandable");
+        let total = 0;
 
         if (q == "") {
             $(".pcontainer label").show();
             sections.each(function () {
                 total++;
-                var left = $(this).data("lbox").children();
+                const left = $(this).data("lbox").children();
                 if (!$(this).hasClass(CLS_CLOSED)) {
                     total += left.length;
                 }
-                for (var i = 0; i < left.length; i++) {
+                for (let i = 0; i < left.length; i++) {
                     // Remove any formatting.
-                    var child = $(left[i]).children().eq(1);
+                    const child = $(left[i]).children().eq(1);
                     child.text(child.text());
                 }
             });
         } else {
-            var re = new RegExp("(" + q.split(' ').join('|') + ")", "gi");
+            const re = new RegExp("(" + q.split(' ').join('|') + ")", "gi");
             sections.each(function () {
-                var found = 0;
-                var left = $(this).data("lbox").children();
-                var right = $(this).data("rbox").children();
-                for (var i = 0; i < left.length; i++) {
-                    var child = $(left[i]).children().eq(1);
-                    var itemText = child.text();
+                let found = 0;
+                const left = $(this).data("lbox").children();
+                const right = $(this).data("rbox").children();
+                for (let i = 0; i < left.length; i++) {
+                    const child = $(left[i]).children().eq(1);
+                    const itemText = child.text();
                     if (itemText.toLocaleLowerCase().indexOf(q) > -1) {
                         child.html(itemText.replace(re, "<b>$1</b>"));
                         found++;
@@ -218,11 +218,11 @@ $(function () {
     $("#pfilter").on("input", filterProperties);
 
     /** Loading image preview ****** */
-    var loadImage = function (node) {
+    const loadImage = function (node) {
         node.imageUrl = URL_LOADING;
         viewController.captureView(node.name).then(imageData => {
-            var blob = new Blob([imageData], { type: "image/png" });
-            var url = createUrl(blob);
+            const blob = new Blob([imageData], { type: "image/png" });
+            const url = createUrl(blob);
             node.imageUrl = url;
             if (node == currentRootNode) {
                 $("#border-box").css('background-image', 'url("' + node.imageUrl + '")');
@@ -239,8 +239,8 @@ $(function () {
         });
     }
 
-    var toggleFavorite = function (e) {
-        var name = $(this).data("pname");
+    const toggleFavorite = function (e) {
+        const name = $(this).data("pname");
         if ($(this).toggleClass(CLS_SELECTED).hasClass(CLS_SELECTED)) {
             favoriteProperties.push(name);
         } else {
@@ -251,10 +251,10 @@ $(function () {
         localStorage.favoriteProps = JSON.stringify(favoriteProperties);
     }
 
-    var propertySectionToggle = function (e) {
-        var me = $(this).toggleClass(CLS_CLOSED);
-        var left = me.data("lbox");
-        var right = me.data("rbox");
+    const propertySectionToggle = function (e) {
+        const me = $(this).toggleClass(CLS_CLOSED);
+        const left = me.data("lbox");
+        const right = me.data("rbox");
         if (closedSections[me.text()] = me.hasClass(CLS_CLOSED)) {
             left.slideUp("fast");
             right.slideUp("fast");
@@ -266,45 +266,45 @@ $(function () {
     }
 
     /********************************* Selecting a node *********************************/
-    var toHex = function(i, len) {
-        var s = i.toString(16);
+    const toHex = function(i, len) {
+        let s = i.toString(16);
         if (s.length < len) {
             s = "0000000000000000".slice(0, len - s.length) + s;
         }
         return s;
     }
 
-    var argb2rgba = function(i) {
+    const argb2rgba = function(i) {
         // ensure unsigned 32-bit int
-        var ui32 = (0xFFFFFFFF & i) >>> 0;
+        const ui32 = (0xFFFFFFFF & i) >>> 0;
         // take one down, pass it around
         return (((ui32 & 0xFFFFFF) << 8) | (ui32 >>> 24));
     }
 
-    var selectNode = function () {
+    const selectNode = function () {
         if ($(this).hasClass(CLS_SELECTED)) return;
         $("#vlist_content .selected").removeClass(CLS_SELECTED);
         $(this).addClass(CLS_SELECTED);
 
         $("#border-box .selected, #image-preview").removeClass(CLS_SELECTED).css('background-image', 'none');
-        var box = $(this).data("box").addClass(CLS_SELECTED);
+        const box = $(this).data("box").addClass(CLS_SELECTED);
 
         // Render properties;
-        var node = $(this).data("node");
-        var nHolder = $("#p_name").empty();
-        var vHolder = $("#p_val").empty();
+        const node = $(this).data("node");
+        const nHolder = $("#p_name").empty();
+        const vHolder = $("#p_val").empty();
 
-        var lastType = "";
-        var nSubHolder = nHolder;
-        var vSubHolder = vHolder;
+        let lastType = "";
+        let nSubHolder = nHolder;
+        let vSubHolder = vHolder;
 
-        var addProp = function (p, type) {
+        const addProp = function (p, type) {
             if (type != lastType) {
                 lastType = type;
 
                 // Add section
-                var section = $("<label>").addClass(CLS_EXPANDABLE).addClass(CLS_WITH_ARROW).text(type).appendTo(nHolder).prepend("<span>");
-                var valspace = $("<label>").html("&nbsp;").appendTo(vHolder);
+                const section = $("<label>").addClass(CLS_EXPANDABLE).addClass(CLS_WITH_ARROW).text(type).appendTo(nHolder).prepend("<span>");
+                const valspace = $("<label>").html("&nbsp;").appendTo(vHolder);
 
                 nSubHolder = $("<div>").appendTo(nHolder);
                 vSubHolder = $("<div>").appendTo(vHolder);
@@ -321,54 +321,54 @@ $(function () {
                 }
             }
 
-            var pName = $("<label>").append($("<span />").text(p.name)).appendTo(nSubHolder);
-            var value = "" + p.value;
+            const pName = $("<label>").append($("<span />").text(p.name)).appendTo(nSubHolder);
+            const value = "" + p.value;
 
-            var labelTag = $("<label>");
+            const labelTag = $("<label>");
 
             if (value == "") {
                 labelTag.html("&nbsp;");
             } else {
-                var valueF = parseFloat(p.value);
-                var valueI = parseInt(p.value);
-                var colorWell = undefined;
+                const valueF = parseFloat(p.value);
+                const valueI = parseInt(p.value);
+                let colorWell = undefined;
 
                 if (!isNaN(valueF)) {
                     // Numbers could mean any number (sorry) of things, so let's try to show 
                     // some relevant interpretations, switchable via <option> drop-down.
-                    var selectTag = $(`<select name="${p.name}">`).append($("<option value='default'>").text(value));
+                    const selectTag = $(`<select name="${p.name}">`).append($("<option value='default'>").text(value));
                     if (viewController.density > 0) {
-                        var dp = Math.round(valueF * 160 * 100 / viewController.density) / 100;
+                        const dp = Math.round(valueF * 160 * 100 / viewController.density) / 100;
                         if (Math.abs(dp) < 10000) {
                             // probably a reasonable dimension
                             selectTag.append($("<option value='size-dp'>").text(dp + " dp"));
                         }
                     }
                     if (valueF == valueI) {
-                        var valueU = valueI >>> 0;
-                        var valueHex = "";
+                        const valueU = valueI >>> 0;
+                        let valueHex = "";
                         if (p.name.search(/color$/i) >= 0) {
                             valueHex = toHex(valueU, 8);
                             selectTag.append(
                                 $("<option value='color-hex'>").text("#" + valueHex)
                             );
                         } else {
-                            var valueHex = toHex(valueU);
+                            valueHex = toHex(valueU);
                             selectTag.append($("<option value='falgs-hex'>").text("0x" + valueHex));
                         }
                         if (valueHex) {
                             colorWell = $("<div>").addClass(CLS_COLORWELL);
                             selectTag.change(() => {
-                                var myVal = "" + selectTag.val();
+                                const myVal = "" + selectTag.val();
                                 if (myVal.startsWith("#")) {
-                                    var webColor = '#' + toHex(argb2rgba(valueU), 8);
+                                    const webColor = '#' + toHex(argb2rgba(valueU), 8);
                                     colorWell.css('display', 'inline-block').css('background-color', webColor);
                                 } else {
                                     colorWell.hide();
                                 }
                             })
                         }
-                        var valuePref = valueTypeMap[p.name];
+                        const valuePref = valueTypeMap[p.name];
                         if (valuePref != undefined && selectTag.children().map(function() { return this.value; }).get().indexOf(valuePref) >= 0) {
                             selectTag.val(valuePref);
                         }
@@ -387,15 +387,15 @@ $(function () {
         }
 
         // Selected properties
-        for (var i = 0; i < favoriteProperties.length; i++) {
-            var prop = node.namedProperties[favoriteProperties[i]];
+        for (let i = 0; i < favoriteProperties.length; i++) {
+            const prop = node.namedProperties[favoriteProperties[i]];
             if (prop) {
                 addProp(prop, "Favorites").addClass(CLS_SELECTED);
             }
         }
 
-        for (var i = 0; i < node.properties.length; i++) {
-            var p = node.properties[i];
+        for (let i = 0; i < node.properties.length; i++) {
+            const p = node.properties[i];
             if (favoriteProperties.indexOf(p.fullname) < 0) {
                 addProp(p, p.type);
             }
@@ -414,17 +414,17 @@ $(function () {
         }
     }
 
-    var saveValueTypeSelect = function() {
+    const saveValueTypeSelect = function() {
         valueTypeMap[$(this).attr("name")] = $(this).val();
-        var data = JSON.stringify(valueTypeMap);
+        const data = JSON.stringify(valueTypeMap);
         localStorage.valueTypeMap = data;
     }
 
-    var profileInfoBox = $("#profile-info");
-    var mouseOverNode = function () {
+    const profileInfoBox = $("#profile-info");
+    const mouseOverNode = function () {
         $(this).data("box").addClass(CLS_HOVER);
 
-        var node = $(this).data("node");
+        const node = $(this).data("node");
         if (node.profiled) {
             profileInfoBox.find("#profile-info-m").text(node.measureTime.toFixed(5));
             profileInfoBox.find("#profile-info-l").text(node.layoutTime.toFixed(5));
@@ -432,25 +432,17 @@ $(function () {
             profileInfoBox.show();            
         }
     }
-    var mouseOutNode = function () {
+    const mouseOutNode = function () {
         $(this).data("box").removeClass(CLS_HOVER);
         profileInfoBox.hide();
     }
 
-    var setEnabled = function (el, isEnabled) {
-        if (isEnabled) {
-            el.removeClass(CLS_DISABLED);
-        } else {
-            el.addClass(CLS_DISABLED);
-        }
-    }
-
-    var showNodeContext = function (e) {
+    const showNodeContext = function (e) {
         e.preventDefault();
         selectNode.call(this);
 
-        var node = $(this).data("node");
-        var menu = [
+        const node = $(this).data("node");
+        const menu = [
             {
                 text: "Save PNG",
                 icon: "ic_save",
@@ -498,44 +490,44 @@ $(function () {
     }
 
     /********************************* Rendering code *********************************/
-    var treeToggle = function (e) {
+    const treeToggle = function (e) {
         $(this).next()[$(this).toggleClass(CLS_CLOSED).hasClass(CLS_CLOSED) ? "hide" : "show"]();
     }
-    var treeToggleFromArrow = function (e) {
+    const treeToggleFromArrow = function (e) {
         $(this).parent().dblclick();
     }
 
-    var renderNode = function (node, container, boxContainer, maxW, maxH, leftShift, topshift, scaleX, scaleY) {
-        var newScaleX = scaleX * node.scaleX;
-        var newScaleY = scaleY * node.scaleY;
+    const renderNode = function (node, container, boxContainer, maxW, maxH, leftShift, topshift, scaleX, scaleY) {
+        const newScaleX = scaleX * node.scaleX;
+        const newScaleY = scaleY * node.scaleY;
 
-        var l = leftShift + (node.left + node.translateX) * scaleX + node.width * (scaleX - newScaleX) / 2;
-        var t = topshift + (node.top + node.translateY) * scaleY + node.height * (scaleY - newScaleY) / 2;
-        var boxPos = {
+        const l = leftShift + (node.left + node.translateX) * scaleX + node.width * (scaleX - newScaleX) / 2;
+        const t = topshift + (node.top + node.translateY) * scaleY + node.height * (scaleY - newScaleY) / 2;
+        const boxPos = {
             left: l,
             top: t,
             width: node.width * newScaleX,
             height: node.height * newScaleY,
         };
 
-        var box = $("<div>").css({
+        const box = $("<div>").css({
             left: (boxPos.left * 100 / maxW) + "%",
             top: (boxPos.top * 100 / maxH) + "%",
             width: (boxPos.width * 100 / maxW) + "%",
             height: (boxPos.height * 100 / maxH) + "%",
         }).appendTo(boxContainer).data("node", node);
 
-        var name = node.name.split(".");
+        let name = node.name.split(".");
         name = name[name.length - 1];
 
-        var desc = node.contentDesc;
+        const desc = node.contentDesc;
         if (desc != null) {
             name = name + " : " + desc;
         }
         node.desc = name;
 
-        var elWrap = $("<x-line-wrap>").text(name).append($("<x-profile>"));
-        var el = $("<label>").appendTo(container).addClass(CLS_WITH_ARROW)
+        const elWrap = $("<x-line-wrap>").text(name).append($("<x-profile>"));
+        const el = $("<label>").appendTo(container).addClass(CLS_WITH_ARROW)
             .data({
                 node: node,
                 box: box
@@ -550,20 +542,20 @@ $(function () {
 
         if (node.children.length) {
             el.addClass(CLS_EXPANDABLE).dblclick(treeToggle);
-            var container = $("<div>").addClass(CLS_TREENODE).appendTo(container);
-            var shiftX = l - node.scrollX;
-            var shiftY = t - node.scrollY;
-            for (var i = 0; i < node.children.length; i++) {
-                renderNode(node.children[i], container, boxContainer, maxW, maxH, shiftX, shiftY, newScaleX, newScaleY);
+            const newContainer = $("<div>").addClass(CLS_TREENODE).appendTo(container);
+            const shiftX = l - node.scrollX;
+            const shiftY = t - node.scrollY;
+            for (let i = 0; i < node.children.length; i++) {
+                renderNode(node.children[i], newContainer, boxContainer, maxW, maxH, shiftX, shiftY, newScaleX, newScaleY);
             }
         }
     }
 
-    var renderList = function (root) {
+    const renderList = function (root) {
         $("#hview").removeClass("hide").removeClass("hidden");
         $("#main-progress").hide();
 
-        var boxContent = $("#border-box").empty();
+        const boxContent = $("#border-box").empty();
         currentRootNode = root;
 
         // Clear all transform from the root, so that it matches the preview
@@ -620,18 +612,18 @@ $(function () {
     }
 
     /********************************* Preview Grid resize *********************************/
-    var resizeBoxView = function () {
+    const resizeBoxView = function () {
         if (!currentRootNode) return;
-        var container = $("#box-border-container");
-        var cW = container.width();
-        var cH = container.height();
+        const container = $("#box-border-container");
+        const cW = container.width();
+        const cH = container.height();
 
-        var mW = currentRootNode.width;
-        var mH = currentRootNode.height;
-        var scale = Math.min(cW / mW, cH / mH);
+        const mW = currentRootNode.width;
+        const mH = currentRootNode.height;
+        const scale = Math.min(cW / mW, cH / mH);
 
-        var w = scale * mW;
-        var h = scale * mH;
+        const w = scale * mW;
+        const h = scale * mH;
         $("#border-box").css({
             width: w,
             height: h,
@@ -642,9 +634,9 @@ $(function () {
     $("#rcontent, #sshot").on("resizing", resizeBoxView);
 
     /** ********************** Box hover handling ***************** */
-    var scrollToNode = function (node) {
+    const scrollToNode = function (node) {
         // expand nodes recursively
-        var parent = node.parent;
+        let parent = node.parent;
         while (parent) {
             if (parent.el.hasClass(CLS_EXPANDABLE) && parent.el.hasClass(CLS_CLOSED)) {
                 parent.el.removeClass(CLS_CLOSED).next().show();
@@ -655,13 +647,13 @@ $(function () {
     }
 
     $("#border-box").mouseover(function (e) {
-        var offset = $(this).offset();
+        const offset = $(this).offset();
 
-        var nodesHidden = !showHiddenNodes;
-        var widthFactor = currentRootNode.width / $(this).width();
-        var heightFactor = currentRootNode.height / $(this).height();
+        const nodesHidden = !showHiddenNodes;
+        const widthFactor = currentRootNode.width / $(this).width();
+        const heightFactor = currentRootNode.height / $(this).height();
 
-        var updateSelection = function (node, x, y, firstNoDrawChild, clipX1, clipY1, clipX2, clipY2) {
+        const updateSelection = function (node, x, y, firstNoDrawChild, clipX1, clipY1, clipX2, clipY2) {
             if (node.disablePreview) {
                 return null;
             }
@@ -672,11 +664,11 @@ $(function () {
                 return null;
             }
 
-            var wasFirstNoDrawChildNull = firstNoDrawChild[0] == null;
-            var boxpos = node.boxpos;
+            const wasFirstNoDrawChildNull = firstNoDrawChild[0] == null;
+            const boxpos = node.boxpos;
 
-            var boxRight = boxpos.width + boxpos.left;
-            var boxBottom = boxpos.top + boxpos.height;
+            const boxRight = boxpos.width + boxpos.left;
+            const boxBottom = boxpos.top + boxpos.height;
             if (node.clipChildren) {
                 clipX1 = Math.max(clipX1, boxpos.left);
                 clipY1 = Math.max(clipY1, boxpos.top);
@@ -684,9 +676,9 @@ $(function () {
                 clipY2 = Math.min(clipY2, boxBottom);
             }
             if (clipX1 < x && clipX2 > x && clipY1 < y && clipY2 > y) {
-                for (var i = node.children.length - 1; i >= 0; i--) {
-                    var child = node.children[i];
-                    var ret = updateSelection(child, x, y, firstNoDrawChild, clipX1, clipY1, clipX2, clipY2);
+                for (let i = node.children.length - 1; i >= 0; i--) {
+                    const child = node.children[i];
+                    const ret = updateSelection(child, x, y, firstNoDrawChild, clipX1, clipY1, clipX2, clipY2);
                     if (ret != null) {
                         return ret;
                     }
@@ -708,15 +700,15 @@ $(function () {
             return null;
         }
 
-        var lastMatch = $("#border-box div.hover").data("node");
-        var findBox = function (e) {
-            var x = (e.pageX - offset.left) * widthFactor;
-            var y = (e.pageY - offset.top) * heightFactor;
-            var firstNoDrawChild = [null];
+        let lastMatch = $("#border-box div.hover").data("node");
+        const findBox = function (e) {
+            const x = (e.pageX - offset.left) * widthFactor;
+            const y = (e.pageY - offset.top) * heightFactor;
+            const firstNoDrawChild = [null];
             return updateSelection(currentRootNode, x, y, firstNoDrawChild, 0, 0, currentRootNode.width, currentRootNode.height);
         }
-        var onMove = function (e) {
-            var found = findBox(e);
+        const onMove = function (e) {
+            const found = findBox(e);
             if (found != lastMatch) {
                 if (lastMatch) {
                     lastMatch.el.removeClass(CLS_HOVER);
@@ -732,13 +724,13 @@ $(function () {
         }
 
         $(this).unbind("mousemove").unbind("click").mousemove(onMove).click(function (e) {
-            var found = findBox(e);
+            const found = findBox(e);
             if (found) {
                 found.el.click();
                 scrollToNode(found);
             }
         }).unbind("contextmenu").bind("contextmenu", function (e) {
-            var found = findBox(e);
+            const found = findBox(e);
             if (found) {
                 showNodeContext.call(found.el.get(0), e);
             }
@@ -750,16 +742,16 @@ $(function () {
     });
 
     /** ********************** Context menu ********************** */
-    var collapseAll = function (node) {
+    const collapseAll = function (node) {
         if (node.el.hasClass(CLS_EXPANDABLE)) {
             node.el.addClass(CLS_CLOSED).next().hide();
-            for (var i = 0; i < node.children.length; i++) {
+            for (let i = 0; i < node.children.length; i++) {
                 collapseAll(node.children[i]);
             }
         }
     }
 
-    var onNodeContextMenuSelected = function () {
+    const onNodeContextMenuSelected = function () {
         switch (this.id) {
             case 0: // save png
                 saveFile(selectedNode.name + ".png", selectedNode.imageUrl);
@@ -792,19 +784,19 @@ $(function () {
     };
 
     /** ********************** Profile view ********************** */
-    var profileView = async function(node) {
-        var data = await viewController.profileView(node.name);
+    const profileView = async function(node) {
+        let data = await viewController.profileView(node.name);
         data = data.split("\n");
-        var index = 0;
+        let index = 0;
 
         function loadProp(n) {
-            var line = data[index];
+            const line = data[index];
             index++;            
             if (!line || line == "-1 -1 -1" || line.toLocaleLowerCase() == "done.") {
                 return false;
             }
 
-            var times = line.split(" ");
+            const times = line.split(" ");
             n.measureTime = (parseInt(times[0]) / 1000.0) / 1000.0;
             n.layoutTime = (parseInt(times[1]) / 1000.0) / 1000.0;
             n.drawTime = (parseInt(times[2]) / 1000.0) / 1000.0;
@@ -826,7 +818,7 @@ $(function () {
         const RED_THRESHOLD = 0.8;
         const YELLOW_THRESHOLD = 0.5;
         function addIndicator(el, name, value) {
-            var e = $("<a>").text(name).appendTo(el);
+            const e = $("<a>").text(name).appendTo(el);
             if (value >= RED_THRESHOLD) {
                 e.addClass("red");
             } else if (value >= YELLOW_THRESHOLD) {
@@ -837,27 +829,27 @@ $(function () {
         }
 
         function setProfileRatings(n) {
-            var N = n.children.length;
+            const N = n.children.length;
             if (N > 1) {
-                var totalMeasure = 0;
-                var totalLayout = 0;
-                var totalDraw = 0;
+                let totalMeasure = 0;
+                let totalLayout = 0;
+                let totalDraw = 0;
                 for (let i = 0; i < N; i++) {
-                    var child = n.children[i];
+                    const child = n.children[i];
                     totalMeasure += child.measureTime;
                     totalLayout += child.layoutTime;
                     totalDraw += child.drawTime;
                 }
                 for (let i = 0; i < N; i++) {
-                    var child = n.children[i];
-                    var el = child.el.find("x-profile").empty().show();
+                    const child = n.children[i];
+                    const el = child.el.find("x-profile").empty().show();
 
                     addIndicator(el, "M", child.measureTime / totalMeasure);
                     addIndicator(el, "L", child.layoutTime / totalLayout);
                     addIndicator(el, "D", child.drawTime / totalDraw);
                 }
             } else if (N == 1) {
-                var child = n.children[0];
+                const child = n.children[0];
                 // Add default
                 child.el.find("x-profile").empty().show()
                     .append($("<a>").text("M"))
@@ -873,10 +865,10 @@ $(function () {
 
 
     /** ********************** Node search ********************** */
-    var lastNodeSearchText = "";
+    let lastNodeSearchText = "";
     $("#btn-search-node").click(function(e) {
-        var searchInput;
-        var elementFactory = function(el, hideMenu) {
+        let searchInput;
+        const elementFactory = function(el, hideMenu) {
             searchInput = $("<input type=search placeholder='Search node'>").appendTo(el);
 
             // Use key up for enter, so that the user has time to press shift key
@@ -895,24 +887,24 @@ $(function () {
         showPopup(e, elementFactory);
         searchInput.val(lastNodeSearchText).focus().select();
 
-        var nodeSearch = function (dir) {
-            var query = searchInput.val();
+        const nodeSearch = function (dir) {
+            let query = searchInput.val();
             if (query == "") return;
             lastNodeSearchText = query;
             query = query.toLocaleLowerCase();
 
             // Search through boxes, as nodes might be collapsed.
-            var boxes = $("#border-box div");
-            var nodes = boxes.filter(function() {
+            const boxes = $("#border-box div");
+            const nodes = boxes.filter(function() {
                 return $(this).css("display") != "none";
             }).map(function () {
                 return $(this).data("node").el.get(0);
             });
 
-            var st = nodes.index(selectedNode.el);
-            var count = nodes.length;
+            let st = nodes.index(selectedNode.el);
+            const count = nodes.length;
 
-            for (var i = -1; i < count; i++) {
+            for (let i = -1; i < count; i++) {
                 st += dir;
                 if (st < 0) {
                     st = count - 1;
@@ -931,21 +923,21 @@ $(function () {
     });
 
     /** ********************** Custom command ********************** */
-    var ignoreNextKeyUp = false;
+    let ignoreNextKeyUp = false;
 
     $("#btn-custom-command").click(function (e) {
-        var commandInput;
-        var errorContainer;
-        var elementFactory = function(el) {
+        let commandInput;
+        let errorContainer;
+        const elementFactory = function(el) {
             commandInput = $("<input type=search placeholder='Custom command'>").appendTo(el);
             errorContainer = $("<div class='custom-command-error-wrapper'>").appendTo(el);
         }
-        var popup = showPopup(e, elementFactory);
+        const popup = showPopup(e, elementFactory);
 
 
         if (viewMethodList != null) {
             // Setup auto complete
-            var methodAutoComplete = new autoComplete({
+            const methodAutoComplete = new autoComplete({
                 selector: commandInput.get(0),
                 minChars: 1,
                 source: autoCompleteSource,
@@ -974,24 +966,24 @@ $(function () {
         });
     })
 
-    var executeCommand = function (cmd, errorContainer) {
+    const executeCommand = function (cmd, errorContainer) {
         cmd = cmd.trim();
-        var m = cmd.match(/^([a-zA-Z_0-9]+)\s*\(([^\)]*)\)\;?$/);
+        const m = cmd.match(/^([a-zA-Z_0-9]+)\s*\(([^)]*)\);?$/);
 
         if (!m) {
             errorContainer.showError("Invalid method format: methodName(param1, param2...). eg: setEnabled(false), setVisibility(0), setAlpha(0.9f)");
             return;
         }
 
-        var data = new DataOutputStream();
+        const data = new DataOutputStream();
         data.writeStr(m[1]);
 
         if (m[2].trim() != "") {
-            var params = m[2].split(",");
+            const params = m[2].split(",");
             data.writeInt(params.length);
-            for (var i = 0; i < params.length; i++) {
+            for (let i = 0; i < params.length; i++) {
                 try {
-                    var p = params[i].trim().toLocaleLowerCase();
+                    let p = params[i].trim().toLocaleLowerCase();
 
                     if (p == "false" || p == "true") {
                         // boolean
@@ -1017,34 +1009,34 @@ $(function () {
         viewController.customCommand(selectedNode.name, data.data).catch(errorContainer.showError.bind(errorContainer));
     }
 
-    var viewMethodList = null;
+    let viewMethodList = null;
 
-    var autoCompleteSource = function (term, suggest) {
+    const autoCompleteSource = function (term, suggest) {
         term = term.toLowerCase().trim();
-        var matches = [];
-        for (var i = 0; i < viewMethodList.length; i++) {
+        const matches = [];
+        for (let i = 0; i < viewMethodList.length; i++) {
             if (~viewMethodList[i][0].toLowerCase().indexOf(term)) matches.push(viewMethodList[i]);
         }
         suggest(matches);
     };
 
-    var suggestionRenderer = function (item, search) {
+    const suggestionRenderer = function (item, search) {
         // escape special characters
-        search = search.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-        var re = new RegExp("(" + search.split(' ').join('|') + ")", "gi");
+        search = search.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+        const re = new RegExp("(" + search.split(' ').join('|') + ")", "gi");
         return '<div class="autocomplete-suggestion" data-val="' + item[0] + '">' + item[0].replace(re, "<b>$1</b>") + "(" + item[1] + ")" + '</div>';
     }
 
-    var loadSuggestions = async function (device) {
+    const loadSuggestions = async function (device) {
         await device.sendFile("/data/local/tmp/methods.jar", "commands/methods.jar");
-        var response = await device.shellCommand("export CLASSPATH=/data/local/tmp/methods.jar;exec app_process /system/bin MethodList");
+        let response = await device.shellCommand("export CLASSPATH=/data/local/tmp/methods.jar;exec app_process /system/bin MethodList");
         response = JSON.parse(response.split("\n", 2)[1]);
         viewMethodList = response;
     };
 
     /** ********************** Main Menu ********************** */
     $("#btn-options").click(function() {
-        var menu = [
+        const menu = [
             {
                 text: "Show hidden node",
                 icon: showHiddenNodes ? "ic_checked" : "ic_unchecked",
@@ -1092,7 +1084,7 @@ $(function () {
             })
         }
 
-        var offset = $(this).offset();
+        const offset = $(this).offset();
         showContext(menu, function (el) {
             switch(this.id) {
                 case 0:
@@ -1124,17 +1116,17 @@ $(function () {
                     switchTheme();
                     break;
                 case 6:
-                    var submenuOffset = el.addClass(CLS_SELECTED).offset();
+                    const submenuOffset = el.addClass(CLS_SELECTED).offset();
                     showPreviewContext({pageX: submenuOffset.left + el.width() / 2, pageY: submenuOffset.top + el.height() / 4})
-                    return true;    // Dont ide te existing popup
+                    return true;    // Don't ide te existing popup
             }
         },
         {pageX: offset.left, pageY: offset.top});
     });
 
-    var currentPreviewMode = 3;
-    var showPreviewContext = function(e) {
-        var menu = [
+    let currentPreviewMode = 3;
+    const showPreviewContext = function(e) {
+        const menu = [
             {
                 text: "Grid",
                 icon: currentPreviewMode == 0 ? "ic_checked" : "ic_unchecked",
@@ -1181,20 +1173,20 @@ $(function () {
 
     /** ********************** Show/hide hidden nodes ********************** */
     // Hides the hode and all its children recursively.
-    var hideNode = function (node, hide) {
+    const hideNode = function (node, hide) {
         hide = hide || !node.isVisible;
         if (hide) {
             node.box.hide();
             node.el.hide();
         }
         if (node.children.length) {
-            for (var i = 0; i < node.children.length; i++) {
+            for (let i = 0; i < node.children.length; i++) {
                 hideNode(node.children[i], hide);
             }
         }
     }
 
-    var showHiddenNodeOptionChanged = function () {
+    const showHiddenNodeOptionChanged = function () {
         if (showHiddenNodes) {
             $("#vlist_content label, #border-box div").show();
         } else {
@@ -1203,9 +1195,9 @@ $(function () {
     }
 
     /** ********************** Save hierarchy ********************** */
-    var saveHierarchy = async function () {
-        var zip = new JSZip();
-        var config = {
+    const saveHierarchy = async function () {
+        const zip = new JSZip();
+        const config = {
             version: 1,
             title: currentAppInfo.name,
             density: viewController.density,
@@ -1215,21 +1207,21 @@ $(function () {
         zip.file("config.json", JSON.stringify(config));
         zip.file("hierarchy.txt", searializeNode(currentRootNode));
 
-        var imgFolder = zip.folder("img");
+        const imgFolder = zip.folder("img");
 
-        var loaders = {};
+        const loaders = {};
         function loadImagesRecur(node) {
             if (node.imageUrl) {
                 loaders[node.name + ".png"] = doXhr(node.imageUrl, 'arraybuffer');
             }
 
-            for (var i = 0; i < node.children.length; i++) {
+            for (let i = 0; i < node.children.length; i++) {
                 loadImagesRecur(node.children[i]);
             }
         }
         loadImagesRecur(currentRootNode);
 
-        for (let name in loaders) {
+        for (const name in loaders) {
             if (loaders[name]) {
                 try {
                     imgFolder.file(name, await loaders[name], { binary: true });

--- a/js/index.js
+++ b/js/index.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var progress;
+let progress;
 
 $(function () {
 	progress = $("#main-progress");
@@ -21,12 +21,12 @@ $(function () {
 		handleSelectDevice(navigator.usb.requestDevice({ filters: [ADB_DEVICE_FILTER] }));
 	});
 
-	var loadFile = function() {
+	const loadFile = function() {
 		if (!this.files || this.files.length < 1) {
 			return;
 		}
 		progress.show();
-		var w = createWorker("js/file_load_worker.js");
+		const w = createWorker("js/file_load_worker.js");
 		w.onerror = function(e) {
 			progress.hide();
 			toast("Not a valid view hierarchy file: " + e.message);
@@ -37,7 +37,7 @@ $(function () {
 					callbacks.windowsLoaded(e.data.list);
 				})
 			} else if (e.data.type == TYPE_ZIP) {
-				var appInfo = e.data;
+				const appInfo = e.data;
 				appInfo.data = new JSZip(appInfo.data);
 				hViewAction(appInfo);
 			} else if (e.data.type == TYPE_ERROR) {
@@ -50,7 +50,7 @@ $(function () {
 		w.postMessage(this.files[0]);
 	}
 	$("#hierarchy-picker-input").on("change", loadFile);
-	var pickerButton = $("#hierarchy-picker")
+	const pickerButton = $("#hierarchy-picker")
 		.click(() => $("#hierarchy-picker-input").click())
 		.on('dragover dragenter', () => pickerButton.addClass('drag_over'))
 		.on('dragleave dragend drop', () => pickerButton.removeClass('drag_over'))
@@ -84,22 +84,22 @@ $(function () {
 
 function refreshConnectedDevices() {
 	navigator.usb.getDevices().then(devices => {
-		let container = $("#connected-devices");
+		const container = $("#connected-devices");
 		container.empty();
 		$("#connected-devices-title")[devices.length == 0 ? "hide" : "show"]();
 		for (let i = 0; i < devices.length; i++) {
-			let d = devices[i];
-			let entry = $("<div>").data("device", d).appendTo(container).click(verifiedDeviceClicked).addClass("entry");
+			const d = devices[i];
+			const entry = $("<div>").data("device", d).appendTo(container).click(verifiedDeviceClicked).addClass("entry");
 			$('<div class="title">').text(d.manufacturerName + " " + d.productName).appendTo(entry);
 
-			let subText = $('<div class="subtext">').appendTo(entry);
+			const subText = $('<div class="subtext">').appendTo(entry);
 			$("<label>").text("serial: " + d.serialNumber).appendTo(subText);
 		}
 	});
 }
 
 function verifiedDeviceClicked() {
-	var d = $(this).data("device");
+	const d = $(this).data("device");
 	handleSelectDevice(Promise.resolve(d));
 }
 
@@ -115,7 +115,7 @@ function handleSelectDevice(devicePromise) {
 		});
 }
 
-var adbDevice;
+let adbDevice;
 
 async function openAndClaim(device) {
 	console.debug("Opening device", device);
@@ -123,11 +123,11 @@ async function openAndClaim(device) {
 	await device.selectConfiguration(1);
 
 	// Find interface
-	var interface = null;
-	var interfaces = device.configuration.interfaces;
-	for (var i = 0; i < interfaces.length; i++) {
+	let interface = null;
+	const interfaces = device.configuration.interfaces;
+	for (let i = 0; i < interfaces.length; i++) {
 		interface = interfaces[i];
-		var iface = interface.alternates[0];
+		const iface = interface.alternates[0];
 		if (iface.interfaceClass === ADB_INTERFACE_CLASS &&
 			iface.interfaceSubclass === ADB_INTERFACE_SUB_CLASS &&
 			iface.interfaceProtocol === ADB_INTERFACE_PROTOCOL) {
@@ -141,7 +141,7 @@ async function openAndClaim(device) {
 	}
 
 	try {
-	  await device.claimInterface(interface.interfaceNumber);
+		await device.claimInterface(interface.interfaceNumber);
 	} catch(e) {
 		console.log("Device is use, trying reset");
 		await device.reset();
@@ -181,14 +181,14 @@ function onDeviceStateChange(newState) {
 
 	document.title = adbDevice.device.manufacturerName + " " + adbDevice.device.productName;
 	activityListAction(function(callbacks) {
-		var client = new DDMClient(adbDevice, callbacks);
+		const client = new DDMClient(adbDevice, callbacks);
 		client.loadOldWindows();
 		client.trackProcesses();
 	});
 }
 
 function switchTheme() {
-	var isDark = $(document.body).toggleClass("darkTheme").hasClass("darkTheme");
+	const isDark = $(document.body).toggleClass("darkTheme").hasClass("darkTheme");
 	$("#darkThemeSwitch").text(isDark ? "Lights on" : "Lights off");
 	localStorage.isDarkTheme = isDark;
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 function deferred(data) {
-	var a, r;
-	var p = new Promise(function(accept, reject) {
+	let a, r;
+	const p = new Promise(function(accept, reject) {
 		a = accept;
 		r = reject;
     });
@@ -30,17 +30,18 @@ class Mutex {
     }
 
     lock() {
-        let nextLock = deferred();
-        let returnAfterCurrentLock = this._lock.then(() => nextLock.accept);
+        const nextLock = deferred();
+        const returnAfterCurrentLock = this._lock.then(() => nextLock.accept);
         this._lock = this._lock.then(() => nextLock);
         return returnAfterCurrentLock;
     }
 }
 
-var ActiveState = [];
+// eslint-disable-next-line prefer-const
+let ActiveState = [];
 
 function createWorker(url) {
-    var worker = new Worker(url);
+    const worker = new Worker(url);
     ActiveState.push(function() {
         worker.terminate();
     });
@@ -48,7 +49,7 @@ function createWorker(url) {
 }
 
 function createUrl(data) {
-    var url = URL.createObjectURL(data);
+    const url = URL.createObjectURL(data);
     ActiveState.push(function() {
         URL.revokeObjectURL(url);
     });
@@ -56,8 +57,8 @@ function createUrl(data) {
 }
 
 function doXhr(url, responseType) {
-    var result = deferred();
-    var xhr = new XMLHttpRequest();
+    const result = deferred();
+    const xhr = new XMLHttpRequest();
     xhr.onreadystatechange = function() {
         if (this.readyState == 4) {
             if (this.status == 200) {
@@ -74,7 +75,7 @@ function doXhr(url, responseType) {
 }
 
 async function saveFile(fileName, url) {
-    var a = $("<a>").attr({href:url, download:fileName}).appendTo(document.body);
+    const a = $("<a>").attr({href:url, download:fileName}).appendTo(document.body);
     a.get(0).click();
     setTimeout(function() {
         a.remove();
@@ -90,23 +91,23 @@ $.fn.showError = function(msg) {
 }
 
 function showContext(menu, callback, e) {
-    var elementFactory = function(el, hideMenu) {
-        var menuClickHandler = function() {
+    const elementFactory = function(el, hideMenu) {
+        const menuClickHandler = function() {
             if (!$(this).hasClass(CLS_DISABLED)) {
                 if (!callback.call($(this).data("info"), $(this))) {
                   hideMenu();
-                };
+                }
             }
         };
 
-        var addSeparator = false;
-        for (var i = 0; i < menu.length; i++) {
-            var m = menu[i];
+        let addSeparator = false;
+        for (let i = 0; i < menu.length; i++) {
+            const m = menu[i];
             if (!m) {
                 addSeparator = true;
                 continue;
             }
-            var item = $("<a class=icon_btn>").text(m.text).addClass(m.icon).appendTo(el).data("info", m).click(menuClickHandler);
+            const item = $("<a class=icon_btn>").text(m.text).addClass(m.icon).appendTo(el).data("info", m).click(menuClickHandler);
             if (addSeparator) {
                 item.addClass("separator");
             }
@@ -128,17 +129,17 @@ function showPopup(e, elementFactory) {
     if (e.preventDefault) {
         e.preventDefault();
     }
-    var wrapper = $("<div class='context-wrapper'>").appendTo(document.body);
-    var el = $("<div class='contextmenu'>").appendTo(wrapper);
+    const wrapper = $("<div class='context-wrapper'>").appendTo(document.body);
+    const el = $("<div class='contextmenu'>").appendTo(wrapper);
 
-    var documentMouseDown = function(e) {
+    const documentMouseDown = function(e) {
         if (!el.has(e.toElement).length) {
             hideMenu();
         }
     };
 
     $(document).mousedown(documentMouseDown);
-    var hideMenu = function() {
+    const hideMenu = function() {
         wrapper.remove();
         $(document).unbind("mousedown", documentMouseDown);
         wrapper.trigger("popup_closed");
@@ -153,7 +154,7 @@ function showPopup(e, elementFactory) {
 }
 
 function toast(msg) {
-    var el = $("<div class=toast>").text(msg).appendTo($("#content")).animate({top: 10, opacity:1}).delay(5000).fadeOut(300, function() { $(this).remove(); });
+    $("<div class=toast>").text(msg).appendTo($("#content")).animate({top: 10, opacity:1}).delay(5000).fadeOut(300, function() { $(this).remove(); });
 }
 
 /**
@@ -161,9 +162,9 @@ function toast(msg) {
  */
 function scrollToView(child, parent) {
     // scroll To View
-    var pTop = parent.stop().offset().top;
-    var elTop = child.stop().offset().top;
-    var delta = 0;
+    const pTop = parent.stop().offset().top;
+    const elTop = child.stop().offset().top;
+    let delta = 0;
     if (elTop < pTop) {
         delta = elTop - pTop - 20;
     } else if ((elTop + child.height()) > pTop + parent.height()) {


### PR DESCRIPTION
Summary: While 'var' can be used anywhere once declared, this is not true for 'let' and 'const'.
They are only valid within their declared scope. This is useful so future developers won't
have to wonder where vars are being used, potentially in a different file with the exception
of global variables like ActiveState. 'Const' is now used wherever possible. This contains
the added benefit over 'let' and 'var' of being immutable (reference-wise). Now devs won't
have to wonder which variables change. Lastly, as ESLint was used to streamline the process
of changing 'var'/'let' to 'const', this commit includes some trivial edits that ESLint
alerted me to like an 'unnecessary backslash in regexp expression' warning or an 'unused parameter' warning.

Test: Did basic sanity testing on a localhost'd web server using previously saved hierarchies, a bug report, and using a live device.