### PR TITLE
Updated the Image Preview UX for file types without an image preview

### DIFF
--- a/css/hview.css
+++ b/css/hview.css
@@ -74,6 +74,7 @@
     transform: scale(0, 0);
     transition: all .2s cubic-bezier(0, 1.4, 1, 1.4);
 }
+
 .pcontainer span.star.selected:after {
     opacity: 1;
     transform: none;
@@ -95,6 +96,10 @@
     z-index: 1;
 }
 
+#border-box.no-image-preview div {
+    box-shadow: 0 0 0 1px black;
+}
+
 #border-box.hide-my-bg div {
     box-shadow: 0 0 0 1px #ddd inset;
 }
@@ -113,6 +118,23 @@
     z-index: 1000;
 }
 
+#border-box.no-image-preview div.hover {
+    box-shadow: 0 0 0 1px black;
+    background: var(--under-cursor-color) !important;
+    opacity: 0.75;
+}
+
+#border-box.no-image-preview div.selected {
+    box-shadow: 0 0 0 1px black;
+    background: var(--selected-color);
+    opacity: 0.5;
+}
+
+#border-box.no-image-preview div.last_selected {
+    box-shadow: 0 0 0 1px black;
+    background: var(--last-selected-color);
+    opacity: 0.5;
+}
 
 #image-preview {
     position: absolute;

--- a/js/constants.js
+++ b/js/constants.js
@@ -18,6 +18,7 @@ const CLS_TREENODE = "treenode";
 const CLS_SELECTED = "selected";
 const CLS_HOVER = "hover";
 const CLS_FORCE_NO_BG = "force-no-bg";
+const CLS_NO_IMAGE_PREVIEW = "no-image-preview";
 const CLS_HIDE_MY_BG = "hide-my-bg";
 const CLS_DISABLED = "disabled";
 const CLS_WITH_ARROW = "with_arrow";
@@ -25,6 +26,7 @@ const CLS_MULTI_TOGGLE = "multi-toggle"
 const CLS_COLORWELL = "colorwell";
 
 const URL_LOADING = "_loading_";
+const NO_IMAGE_LOADED_MESSAGE = "Image not found"
 
 const TYPE_ERROR = -1;
 const TYPE_ZIP = 0;

--- a/js/ddmlib/ddmclient.js
+++ b/js/ddmlib/ddmclient.js
@@ -334,7 +334,7 @@ class OfflineServiceController {
     async captureView(viewName) {
         const file = this.zip.file("img/" + viewName + ".png");
         if (!file) {
-            throw "Image not found";
+            throw NO_IMAGE_LOADED_MESSAGE;
         }
         return file.asUint8Array();
     }
@@ -377,7 +377,7 @@ class BugReportServiceController {
     }
 
     async captureView(viewName) {
-        throw "Image not found";
+        throw NO_IMAGE_LOADED_MESSAGE;
     }
 }
 

--- a/js/hview.js
+++ b/js/hview.js
@@ -231,10 +231,13 @@ $(function () {
                 node.box.css('background-image', 'url("' + node.imageUrl + '")');
                 $("#image-preview").empty().css('background-image', 'url("' + node.imageUrl + '")');
             }
-        }).catch(() => {
+        }).catch((e) => {
             node.imageUrl = null;
             if (node.box.hasClass(CLS_SELECTED)) {
                 $("#image-preview").showError("Error loading image");
+            }
+            if (e == NO_IMAGE_LOADED_MESSAGE && shouldEnableImagePreviewMode()) {
+                $("#border-box").addClass(CLS_NO_IMAGE_PREVIEW)
             }
         });
     }
@@ -293,6 +296,12 @@ $(function () {
         const node = $(this).data("node");
         const nHolder = $("#p_name").empty();
         const vHolder = $("#p_val").empty();
+
+        if ($("#border-box").hasClass(CLS_NO_IMAGE_PREVIEW)) {
+            addClassToNodeAndChildNodeBoxes(node, CLS_SELECTED)
+        } else {
+            node.box.addClass(CLS_SELECTED)
+        }
 
         let lastType = "";
         let nSubHolder = nHolder;
@@ -412,6 +421,21 @@ $(function () {
         } else {
             loadImage(node);
         }
+    }
+
+    const addClassToNodeAndChildNodeBoxes = (node /* ViewNode */, _class /* String */) => {
+        if (node != null) {
+            if (node.box != null) {
+                node.box.addClass(_class)
+            }
+            for (let i = 0; i < node.children.length; i++) {
+                addClassToNodeAndChildNodeBoxes(node.children[i], _class)
+            }
+        }
+    }
+
+    const shouldEnableImagePreviewMode = () => {
+        return $("#border-box").css('background-image') == 'none'  && $("#image-preview").css('background-image') == 'none'
     }
 
     const saveValueTypeSelect = function() {
@@ -1155,19 +1179,20 @@ $(function () {
         showContext(menu, function () {
             switch (this.id) {
                 case 0:  // only grid
-                    $("#border-box").addClass(CLS_FORCE_NO_BG).addClass(CLS_HIDE_MY_BG);
+                    $("#border-box").addClass(CLS_FORCE_NO_BG).addClass(CLS_HIDE_MY_BG).addClass(CLS_NO_IMAGE_PREVIEW);
                     $("#image-preview").hide();
                     break;
                 case 1: // Only image
                     $("#image-preview").show();
+                    $("#border-box").removeClass(CLS_NO_IMAGE_PREVIEW);
                     break;
                 case 2: // both
                     $("#image-preview").hide();
-                    $("#border-box").removeClass(CLS_FORCE_NO_BG).addClass(CLS_HIDE_MY_BG);
+                    $("#border-box").removeClass(CLS_FORCE_NO_BG).addClass(CLS_HIDE_MY_BG).addClass(CLS_NO_IMAGE_PREVIEW);
                     break;
                 case 3: // App view
                     $("#image-preview").hide();
-                    $("#border-box").addClass(CLS_FORCE_NO_BG).removeClass(CLS_HIDE_MY_BG);
+                    $("#border-box").addClass(CLS_FORCE_NO_BG).removeClass(CLS_HIDE_MY_BG).toggleClass(CLS_NO_IMAGE_PREVIEW, shouldEnableImagePreviewMode());
                     break;
             }
             currentPreviewMode = this.id;


### PR DESCRIPTION
… like a bug report or a zip file.

This new UX can also be activated/deactivated by choosing a different preview type via the hview context menu.
The new UX highlights the background (recursively to show depth) rather than just the border.

Prerequisite: https://github.com/google/web-hv/pull/15

Here is an example of the UX (assuming the dev-colors CL gets merged as well):
<img width="1883" alt="image" src="https://user-images.githubusercontent.com/104465970/176931288-f55d090a-ca17-4051-8041-b0036ae8b798.png">