### PR TITLE
Optimize rendering and processing latencies for Time Lapse View Hierarchies

### DIFF
--- a/js/activity_list.js
+++ b/js/activity_list.js
@@ -33,7 +33,6 @@ const activityListAction = function (initializer) {
         };
 
         if (info.type == TYPE_TIME_LAPSE_BUG_REPORT) {
-            toast("Loading time lapse data. This can take longer than 10 seconds.")
             tlHvAction(info)
         } else {
             hViewAction(info);


### PR DESCRIPTION
Processing an individual view hierarchy now takes ~2ms. Showing the first one on the screen takes ~16.5ms. Switching view hierarchies takes ~2.5ms. Processing 170 view hierarchies without jank on the UI thread takes ~650ms. All of these numbers were recorded using Launcher view hierarchy data.

Testing: Manually regression testing. Tested live data, zip files, other bug report screens, etc.
Todo: Move some of the node processing into the background thread. Fix the properties screen.

Go here: https://sandonian.github.io/, to see the updated functionality.