### PR TITLE
Moved property formatting for all View Hierarchy data, and ViewNode p…

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,6 @@
     <script src="third_party/auto-complete.min.js"></script>
     <script src="third_party/jszip.min.js"></script>
     <script src="third_party/jmuxer.min.js"></script>
-    <script src="third_party/protobuf.min.js"></script>
 
     <script src="js/constants.js"></script>
     <script src="js/utils.js"></script>

--- a/js/constants.js
+++ b/js/constants.js
@@ -41,9 +41,5 @@ const CMD_USE_PROPERTY_MAP = 4;
 const CMD_DEFLATE_STRING = 8;
 const CMD_SKIP_8_BITS = 16;
 
-/* Temporary value to enable development with mock data
-   until a better way can be implemented using real data. */
-const MULTI_ZIP_CONFIG_VERSION = 22;
-
 const VIEW_VISIBLE = 0;
 const VIEW_CAPTURE_REGEX = /^\s*mViewCapture:\s*/

--- a/js/ddmlib/ddmclient.js
+++ b/js/ddmlib/ddmclient.js
@@ -287,21 +287,7 @@ function parseViewData(data, cmd, callback) {
         callback.reject("Error parsing view data");
     }
     w.onmessage = function (e) {
-        const root = e.data.root;
-        const setParent = function (node) {
-            for (let i = 0; i < node.children.length; i++) {
-                node.children[i].parent = node;
-                setParent(node.children[i]);
-            }
-
-            // Update named properties.
-            node.namedProperties = {};
-            for (let i = 0; i < node.properties.length; i++) {
-                node.namedProperties[node.properties[i].fullname] = node.properties[i];
-            }
-        }
-        setParent(root);
-        callback.accept(root);
+        callback.accept(e.data.viewHierarchyData);
     }
     w.postMessage({ cmd: cmd, data: data });
 }
@@ -340,24 +326,13 @@ class OfflineServiceController {
     }
 }
 
-class TimeLapseBugReportServiceController {
-    constructor(appInfo) {
-        this.bugReportLine = appInfo.data
-    }
-
+class NoOpServiceController {
     loadViewList() {
-        const base64String = this.bugReportLine.replace(VIEW_CAPTURE_REGEX, "")
-
-        return protobuf.load("../protos/view_capture.proto").then(function (root) {
-            return root.lookupType("com.android.launcher3.view.ExportedData")
-                       .decode(base64ToUint8Array(base64String))
-                       .frameData
-                       .map(x => x.node)
-        })
+        throw "loadViewList() is not implemented. You might be using the wrong ServiceController.";
     }
 
     async captureView(viewName) {
-        throw "Image not found";
+        throw "Image not found"
     }
 }
 

--- a/js/ddmlib/property_formatter.js
+++ b/js/ddmlib/property_formatter.js
@@ -1,0 +1,107 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const EXCLUSION_LIST = new Set([ "toJSON", "$type", "constructor", "namedProperties", "properties", "children", "parent", "classname", "name", "boxPos", "boxStylePos", "desc" ])
+
+const LAYOUT_TYPE = "Layout"
+const DRAWING_TYPE = "Drawing"
+const SCROLLING_TYPE = "Scrolling"
+const MISC_TYPE = "Misc"
+const DEFAULT_TYPE = "Unspecified"
+
+const PROPERTY_TYPE_MAP = new Map()
+PROPERTY_TYPE_MAP.set("left", LAYOUT_TYPE)
+PROPERTY_TYPE_MAP.set("top", LAYOUT_TYPE)
+PROPERTY_TYPE_MAP.set("width", LAYOUT_TYPE)
+PROPERTY_TYPE_MAP.set("height", LAYOUT_TYPE)
+PROPERTY_TYPE_MAP.set("scrollX", SCROLLING_TYPE)
+PROPERTY_TYPE_MAP.set("scrollY", SCROLLING_TYPE)
+PROPERTY_TYPE_MAP.set("translationX", DRAWING_TYPE)
+PROPERTY_TYPE_MAP.set("translationY", DRAWING_TYPE)
+PROPERTY_TYPE_MAP.set("scaleX", DRAWING_TYPE)
+PROPERTY_TYPE_MAP.set("scaleY", DRAWING_TYPE)
+PROPERTY_TYPE_MAP.set("alpha", DRAWING_TYPE)
+PROPERTY_TYPE_MAP.set("willNotDraw", DRAWING_TYPE)
+PROPERTY_TYPE_MAP.set("clipChildren", DRAWING_TYPE)
+PROPERTY_TYPE_MAP.set("visibility", MISC_TYPE)
+PROPERTY_TYPE_MAP.set("id", DEFAULT_TYPE)
+
+/* returns the root ViewNode that was passed in and altered */
+const formatProperties = function(root /* ViewNode */) {
+    function inner(node /* ViewNode */,
+                   maxW /* Int */,
+                   maxH /* Int */,
+                   leftShift /* Int */,
+                   topShift /* Int */,
+                   scaleX /* Int */,
+                   scaleY /* Int */) {
+        const newScaleX = scaleX * node.scaleX
+        const newScaleY = scaleY * node.scaleY
+
+        const l = leftShift + (node.left + node.translationX) * scaleX + node.width * (scaleX - newScaleX) / 2
+        const t = topShift + (node.top + node.translationY) * scaleY + node.height * (scaleY - newScaleY) / 2
+        node.boxPos = {
+            left: l,
+            top: t,
+            width: node.width * newScaleX,
+            height: node.height * newScaleY,
+        }
+
+        node.boxStylePos = {
+            left: (node.boxPos.left * 100 / maxW) + "%",
+            top: (node.boxPos.top * 100 / maxH) + "%",
+            width: (node.boxPos.width * 100 / maxW) + "%",
+            height: (node.boxPos.height * 100 / maxH) + "%"
+        }
+
+        if (node.name == undefined) {
+            node.name = node.classname
+        }
+
+        let tName = node.name.split(".");
+        node.name = tName[tName.length - 1];
+
+        if (node.contentDesc != null) {
+            node.name = node.name + " : " + node.contentDesc;
+        }
+        node.desc = node.name;
+
+        for (let i = 0; i < node.children.length; i++) {
+            node.children[i].parent = node;
+            inner(node.children[i], maxW, maxH, l - node.scrollX, t - node.scrollY, newScaleX, newScaleY);
+        }
+
+        if (node.properties == undefined) {
+            node.properties = []
+
+            for (const propertyName in node) {
+                if (!EXCLUSION_LIST.has(propertyName)) {
+                    const property = new VN_Property(propertyName)
+                    property.value = node[propertyName]
+                    property.type = PROPERTY_TYPE_MAP.get(propertyName) || DEFAULT_TYPE
+                    node.properties.push(property)
+                }
+            }
+        }
+        node.namedProperties = {};
+        for (let i = 0; i < node.properties.length; i++) {
+            node.namedProperties[node.properties[i].fullname] = node.properties[i];
+        }
+    }
+
+    root.scaleX = root.scaleY = 1;
+    root.translationX = root.translationY = 1;
+    inner(root, root.width, root.height, 0, 0, 1, 1)
+    return root
+}

--- a/js/ddmlib/tl-worker.js
+++ b/js/ddmlib/tl-worker.js
@@ -1,0 +1,54 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+importScripts("property_formatter.js")
+importScripts("../../third_party/protobuf.min.js")
+importScripts("viewnode.js")
+
+let rootNodes /* ViewNode[] */
+let formattingIndex = 0
+
+self.onmessage = function(event) {
+    if (rootNodes == null) {
+        protobuf.load("../../protos/view_capture.proto").then(function(root) {
+            rootNodes = root.lookupType("com.android.launcher3.view.ExportedData")
+                            .decode(event.data.tlHvDataAsBinaryArray)
+                            .frameData
+                            .map(f => f.node)
+            postMessage({ frameCount: rootNodes.length })
+            formatNextNode()
+        })
+    } else {
+        sendNodeToUiThread(event.data.processedIndex)
+    }
+}
+
+/* If the Ui thread processes nodes faster than the worker thread can format them,
+   wait for the next node to be formatted before sending it. */
+function sendNodeToUiThread(processedIndex) {
+    if (processedIndex < formattingIndex && processedIndex < rootNodes.length) {
+        postMessage({ rootNode: rootNodes[processedIndex] })
+    } else {
+        setTimeout(sendNodeToUiThread, 1, processedIndex)
+    }
+}
+
+/* Pause processing for 1 ms so that the worker thread can respond to messages
+   sent from the main thread request an additional formatted node to process. */
+function formatNextNode() {
+    if (formattingIndex < rootNodes.length) {
+        formatProperties(rootNodes[formattingIndex])
+        setTimeout(formatNextNode, 1, ++formattingIndex)    
+    }
+}

--- a/js/ddmlib/worker.js
+++ b/js/ddmlib/worker.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 importScripts("viewnode.js");
+importScripts("property_formatter.js");
 
 const CMD_CONVERT_TO_STRING = 1;
 const CMD_PARSE_OLD_DATA = 2;
@@ -80,8 +81,10 @@ self.onmessage = function(e) {
     }
 
     const rootNode = parseNode(data, bitShift);
+    formatProperties(rootNode);
+
     postMessage({
-        root: rootNode
+        viewHierarchyData: rootNode
     });
     close();
 }

--- a/js/file_load_worker.js
+++ b/js/file_load_worker.js
@@ -14,6 +14,7 @@
 
 importScripts("../third_party/jszip.min.js");
 importScripts("constants.js");
+importScripts("utils.js")
 
 self.onmessage = function(e) {
     const reader = new FileReader();
@@ -60,9 +61,7 @@ async function handleLoadFile(reader) {
     const config = JSON.parse(zip.file("config.json").asText());
     const appInfo = { type: TYPE_ZIP, data: reader.result, config: config, name: config.title };
 
-    if (config.version == MULTI_ZIP_CONFIG_VERSION) {
-        appInfo.type = TYPE_MULTI_FILE_ZIP;
-    } else if (config.version != 1 || !config.title || zip.file("hierarchy.txt") == null) {
+    if (config.version != 1 || !config.title || zip.file("hierarchy.txt") == null) {
         throw "Missing data"
     }
 
@@ -137,9 +136,12 @@ async function loadBugFile(bugFile, list) {
     let line;
     while ((line = liner.next()) != null) {
         if (VIEW_CAPTURE_REGEX.test(line)) {
+            const tlHvDataAsBase64String = line.replace(VIEW_CAPTURE_REGEX, "")
+            const tlHvDataAsBinaryArray = base64ToUint8Array(tlHvDataAsBase64String)
+
             list.push({
                 name: "Launcher's View Capture",
-                data: line,
+                data: tlHvDataAsBinaryArray,
                 type: TYPE_TIME_LAPSE_BUG_REPORT,
                 display: { }
             })

--- a/js/index.js
+++ b/js/index.js
@@ -196,3 +196,11 @@ function switchTheme() {
 function isDarkTheme() {
 	return localStorage.isDarkTheme == "true";
 }
+
+/**
+ * Adds a node displaying the error message in the container
+ */
+$.fn.showError = function(msg) {
+  $("#main-progress").hide();
+  return this.empty().removeClass("hide").removeClass("hidden").append($("<span>").text(msg).addClass("error"));
+}

--- a/js/utils.js
+++ b/js/utils.js
@@ -82,14 +82,6 @@ async function saveFile(fileName, url) {
     }, 0);
 }
 
-/**
- * Adds a node displaying the error message in the continer
- */
-$.fn.showError = function(msg) {
-  $("#main-progress").hide();
-  return this.empty().removeClass("hide").removeClass("hidden").append($("<span>").text(msg).addClass("error"));
-}
-
 function showContext(menu, callback, e) {
     const elementFactory = function(el, hideMenu) {
         const menuClickHandler = function() {


### PR DESCRIPTION
Moved property formatting for all View Hierarchy data, and ViewNode parsing for time lapse view hierarchy data to the background thread. Also changed processing model so that instead of waiting for the background thread to process then switching to the main thread to process everything, both threads are processing the data simultaneously and communicating with each other much more frequently.

I also realized a bug where the properties UX wasn't being updated on switching nodes. 

With these new changes, the time to usability is 150ms, the total processing time is between 1 - 2 seconds, and no jank is noticeable, at least to my eyes.

Switching ViewHierarchies now takes ~12ms, but that can probably be optimized by replacing jQuery with native DOM manipulation. I will explore this route locally, and probably put out a CL for that soon, but not yet since this CL is already getting huge.

Test these changes here: https://sandonian.github.io/