### PR TITLE
Fixed display UX for tree nodes with content descriptions

### DIFF
--- a/js/ddmlib/property_formatter.js
+++ b/js/ddmlib/property_formatter.js
@@ -21,7 +21,7 @@ const EXCLUSION_LIST = new Set([
     "children",
     "parent",
     "classname",
-    "simpleName",
+    "treeDisplayName",
     "name",
     "boxPos",
     "boxStylePos",
@@ -85,13 +85,13 @@ const formatProperties = function(root /* ViewNode */) {
             node.name = node.classname
         }
 
-        node.simpleName = node.name.split(".")
-        node.simpleName = node.simpleName[node.simpleName.length - 1];
+        node.treeDisplayName = node.name.split(".")
+        node.treeDisplayName = node.treeDisplayName[node.treeDisplayName.length - 1];
 
         if (node.contentDesc != null) {
-            node.name = node.name + " : " + node.contentDesc;
+            node.treeDisplayName = node.treeDisplayName + " : " + node.contentDesc;
         }
-        node.desc = node.name;
+        node.desc = node.treeDisplayName;
         node.isVisible = node.visibility == 0 || node.visibility == "VISIBLE" || node.visibility == undefined
         node.nodeDrawn = !node.willNotDraw;
 

--- a/js/hview.js
+++ b/js/hview.js
@@ -577,7 +577,7 @@ $(function () {
 
         const elWrap = xlinewrapProtoType.cloneNode()
         elWrap.appendChild(span)
-        elWrap.appendChild(document.createTextNode(node.simpleName))
+        elWrap.appendChild(document.createTextNode(node.treeDisplayName))
         elWrap.appendChild(xprofileProtoType.cloneNode())
     
         const el = labelProtoType.cloneNode()


### PR DESCRIPTION
The content description was not being appended to the tree view nodes.
Also, the images weren't rendering in the image preview when using "image" mode.

Below is a screenshot of what was fixed:
<img width="762" alt="image" src="https://user-images.githubusercontent.com/104465970/184454588-b07e7202-961a-4501-9a4c-e805c3f1750e.png">
