### PR TITLE
Add missing arrow to tree node in hierarchy view

### DIFF
--- a/js/hview.js
+++ b/js/hview.js
@@ -582,6 +582,7 @@ $(function () {
     
         const el = labelProtoType.cloneNode()
         container.appendChild(el)
+        el.classList.add(CLS_WITH_ARROW)
         el.onclick = selectNode
         el.onmouseover = mouseOverNode
         el.onmouseout = mouseOutNode


### PR DESCRIPTION
The arrows circled below were missing:
<img width="526" alt="image" src="https://user-images.githubusercontent.com/104465970/184456300-98d78931-6458-424b-9d87-2e0ca6a0b4e6.png">
