### PR TITLE
Get elevation in time-lapse View Hierarchy capture.

### DIFF
--- a/js/ddmlib/property_formatter.js
+++ b/js/ddmlib/property_formatter.js
@@ -41,6 +41,7 @@ PROPERTY_TYPE_MAP.set("left", LAYOUT_TYPE)
 PROPERTY_TYPE_MAP.set("top", LAYOUT_TYPE)
 PROPERTY_TYPE_MAP.set("width", LAYOUT_TYPE)
 PROPERTY_TYPE_MAP.set("height", LAYOUT_TYPE)
+PROPERTY_TYPE_MAP.set("elevation", LAYOUT_TYPE)
 PROPERTY_TYPE_MAP.set("scrollX", SCROLLING_TYPE)
 PROPERTY_TYPE_MAP.set("scrollY", SCROLLING_TYPE)
 PROPERTY_TYPE_MAP.set("translationX", DRAWING_TYPE)
@@ -112,6 +113,8 @@ const formatProperties = function(root /* ViewNode */) {
                     node.properties.push(property)
                 }
             }
+
+            node.properties.sort((a, b) => PROPERTY_TYPE_MAP.get(a.name).localeCompare(PROPERTY_TYPE_MAP.get(b.name)))
         }
         node.namedProperties = {};
         for (let i = 0; i < node.properties.length; i++) {

--- a/protos/view_capture.proto
+++ b/protos/view_capture.proto
@@ -50,4 +50,6 @@ message ViewNode {
   optional int32 visibility = 16;
 
   repeated ViewNode children = 17;
+
+  optional float elevation = 18;
 }


### PR DESCRIPTION
I did latency testing to make sure the sorting doesn't increase latency. Although it increases the time required to formatProperties from ~.7ms to ~1.2, it still doesn't increase the time to process the entire collection of view hierarchies because formatProperties happens on a background thread, and still finishes faster than the preprocessing that happens on the main thread.

Bug: 234032088
Test: Verified that elevation attributes from device are captured and
show up correctly on go/web-hv UI.