### PR TITLE
Fixing 2  Minor Bugs affecting the UI.

### DIFF
--- a/js/hview.js
+++ b/js/hview.js
@@ -615,6 +615,8 @@ $(function () {
     /********************************* Refresh view *********************************/
     hViewAction = function (appInfo) {
         showViewHierarchyUX()
+        $(".slider-group").addClass("hidden visible")
+        $("#vlist, #border-box").removeClass("multi-page")
 
         viewController = createViewController(appInfo);
         viewController.loadViewList().then(rootNode => {

--- a/js/hview.js
+++ b/js/hview.js
@@ -535,7 +535,7 @@ $(function () {
         }
         menu.push(null);
 
-        if (!this.node.disablePreview) {
+        if (!this.node.el.classList.contains("preview-disabled")) {
             menu.push({
                 text: "Disable preview",
                 icon: "ic_hide",
@@ -883,7 +883,7 @@ $(function () {
         const heightFactor = currentRootNode.height / $(this).height();
 
         const updateSelection = function (node, x, y, firstNoDrawChild, clipX1, clipY1, clipX2, clipY2) {
-            if (node.disablePreview || !node.nodeDrawn || (nodesHidden && !node.isVisible)) {
+            if (node.el.classList.contains("preview-disabled") || !node.nodeDrawn || (nodesHidden && !node.isVisible)) {
                 return null;
             }
 
@@ -988,11 +988,9 @@ $(function () {
                 profileView(selectedNode);
                 break;
             case 3: // Disable preview
-                selectedNode.disablePreview = true;
                 selectedNode.el.classList.add("preview-disabled");
                 break;
             case 4: // Enable preview
-                selectedNode.disablePreview = false;
                 selectedNode.el.classList.remove("preview-disabled");
                 break;
             case 5: // Collapse all


### PR DESCRIPTION
a. Sometimes a disabled "box" is re-enabled for selecting, even though the tree "el" is disabled when switching moments in time. This was fixed by making the "el" the single source of truth, rather than attempting to update the node attributes correctly.
b. Doing the following incorrectly was showing the time-lapse UI:
     1. Entering time-lapse UI
     2. Going back to the activity chooser page
     3. Entering a single-moment UI
This was fixed by removing the css classes that showed the time-lapse UI when entering a single-moment UI everytime, since when the classes aren't attached anyways it does nothing.